### PR TITLE
feat: add gpsampler support for optuna

### DIFF
--- a/auto_tune_vllm/core/config.py
+++ b/auto_tune_vllm/core/config.py
@@ -107,7 +107,7 @@ class OptimizationConfig:
     
     # Backward compatibility fields
     objective: Union[str, List[str]] = None  # Old format: "maximize", "minimize", or list
-    sampler: str = "tpe"  # "tpe", "random", "botorch", "nsga2", "grid" 
+    sampler: str = "tpe"  # "tpe", "random", "gp", "botorch", "nsga2", "grid" 
     n_trials: int = 100
     n_startup_trials: Optional[int] = None  # Number of startup trials for samplers that support it
     max_concurrent: Optional[int] = None  # Maximum concurrent trials (required for resource management)

--- a/auto_tune_vllm/core/study_controller.py
+++ b/auto_tune_vllm/core/study_controller.py
@@ -9,7 +9,8 @@ from typing import Dict, Optional, List
 
 import optuna
 from optuna.samplers import (
-    GridSampler, 
+    GridSampler,
+    GPSampler,
     NSGAIISampler,
     RandomSampler,
     TPESampler
@@ -309,6 +310,8 @@ class StudyController:
             return TPESampler()
         elif sampler_name == "random":
             return RandomSampler()
+        elif sampler_name == "gp":
+            return GPSampler()
         elif sampler_name == "botorch":
             return optuna.integration.BoTorchSampler()
         elif sampler_name == "nsga2":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ dependencies = [
     "typer>=0.9.0",
     "rich>=13.0.0",
     "requests>=2.28.0",
+    "gpytorch>=1.1"
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
# Purpose

adding support for the Gaussian Process Sampler. This will require some testing to see if it provides any benefit over BOTorch. While the sampler is technically experimental, it has a decent amount of support for multiobjective optimizations as of [Optuna v4.40](https://github.com/optuna/optuna/releases/tag/v4.4.0) and should in theory perform better than BOTorch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added a Gaussian Process (“gp”) sampler option for hyperparameter tuning, available alongside existing samplers.

- Documentation
  - Updated configuration description to include “gp” as a supported sampler option.

- Chores
  - Added a runtime dependency (gpytorch) required to support the new GP sampler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->