### PR TITLE
Feature/preserve benchmark results

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,13 @@ pip install auto-tune-vllm
 #### CLI Interface
 ```bash
 # Run optimization study
-auto-tune-vllm optimize --config study_config.yaml
+auto-tune-vllm optimize --config config.yaml --max-concurrent 2
 
 # Stream live logs  
 auto-tune-vllm logs --study-id 42 --trial-number 15
 
 # Resume interrupted study
-auto-tune-vllm resume --study-id 42
+auto-tune-vllm resume --study-name study_35884
 ```
 
 

--- a/auto_tune_vllm/benchmarks/config.py
+++ b/auto_tune_vllm/benchmarks/config.py
@@ -9,7 +9,7 @@ class BenchmarkConfig:
     """Configuration for benchmark execution."""
     
     benchmark_type: str = "guidellm"  # "guidellm" or custom provider name
-    model: str = "Qwen/Qwen3-30B-A3B-FP8"
+    model: str = "RedHatAI/Qwen3-30B-A3B-FP8-dynamic"
     max_seconds: int = 300
     dataset: Optional[str] = None  # HF dataset or file path
     prompt_tokens: int = 1000  # For synthetic data

--- a/auto_tune_vllm/cli/main.py
+++ b/auto_tune_vllm/cli/main.py
@@ -69,7 +69,7 @@ def optimize_command(
     config: str = typer.Option(..., "--config", "-c", help="Study configuration file"),
     backend: str = typer.Option("ray", "--backend", "-b", help="Execution backend: 'ray' (only supported option)"),
     n_trials: Optional[int] = typer.Option(None, "--trials", "-n", help="Number of trials (overrides config)"),
-    max_concurrent: Optional[int] = typer.Option(None, "--max-concurrent", help="REQUIRED: Max concurrent trials (1=single GPU, 2=dual GPU, etc.)"),
+    max_concurrent: Optional[int] = typer.Option(None, "--max-concurrent", help="REQUIRED: Max concurrent trials to run simultaneously."),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose logging"),
     create_db: bool = typer.Option(False, "--create-db", help="Create database if it doesn't exist"),
     start_ray_head: bool = typer.Option(False, "--start-ray-head", help="Start Ray head if no cluster is found"),
@@ -139,6 +139,13 @@ def optimize_command(
         # Run optimization
         # Use CLI value or fall back to YAML config
         final_max_concurrent = max_concurrent or study_config.optimization.max_concurrent
+        if final_max_concurrent is None:
+            console.print("[bold red]❌ --max-concurrent is required (or set optimization.max_concurrent in the config)[/bold red]")
+            console.print("YAML:\n  optimization:\n    max_concurrent: 2  # Match your GPU count")
+            raise typer.Exit(1)
+        if final_max_concurrent < 1:
+            console.print("[bold red]❌ --max-concurrent must be >= 1[/bold red]")
+            raise typer.Exit(1)
         
         run_optimization_sync(
             execution_backend, 
@@ -574,7 +581,7 @@ def resume_command(
     backend: str = typer.Option("ray", "--backend", "-b", help="Execution backend: 'ray' (only supported option)"),
     n_trials: Optional[int] = typer.Option(None, "--trials", "-n", help="Number of additional trials to run"),
     n_total_trials: Optional[int] = typer.Option(None, "--total-trials", help="Total number of trials to reach (overrides config)"),
-    max_concurrent: Optional[int] = typer.Option(None, "--max-concurrent", help="REQUIRED: Max concurrent trials (1=single GPU, 2=dual GPU, etc.)"),
+    max_concurrent: Optional[int] = typer.Option(None, "--max-concurrent", help="REQUIRED: Max concurrent trials to run simultaneously (should match your GPU count)"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose logging"),
     start_ray_head: bool = typer.Option(False, "--start-ray-head", help="Start Ray head if no cluster is found"),
     python_executable: Optional[str] = typer.Option(None, "--python-executable", help="Explicit Python executable path for Ray workers"),
@@ -625,8 +632,16 @@ def resume_command(
         # Resume study
         # Use CLI value or fall back to YAML config
         final_max_concurrent = max_concurrent or study_config.optimization.max_concurrent
+        if (n_trials or n_total_trials):  # Only required if we will run new trials
+            if final_max_concurrent is None:
+                console.print("[bold red]❌ --max-concurrent is required to resume with new trials[/bold red]")
+                console.print("Set CLI flag or config: optimization.max_concurrent")
+                raise typer.Exit(1)
+            if final_max_concurrent < 1:
+                console.print("[bold red]❌ --max-concurrent must be >= 1[/bold red]")
+                raise typer.Exit(1)
         resume_study_sync(execution_backend, study_config, n_trials, n_total_trials, final_max_concurrent)
-        
+
     except Exception as e:
         console.print(f"[bold red]Resume failed: {e}[/bold red]")
         if verbose:

--- a/auto_tune_vllm/cli/main.py
+++ b/auto_tune_vllm/cli/main.py
@@ -69,7 +69,7 @@ def optimize_command(
     config: str = typer.Option(..., "--config", "-c", help="Study configuration file"),
     backend: str = typer.Option("ray", "--backend", "-b", help="Execution backend: 'ray' (only supported option)"),
     n_trials: Optional[int] = typer.Option(None, "--trials", "-n", help="Number of trials (overrides config)"),
-    max_concurrent: Optional[int] = typer.Option(None, "--max-concurrent", help="Max concurrent trials"),
+    max_concurrent: Optional[int] = typer.Option(None, "--max-concurrent", help="REQUIRED: Max concurrent trials (1=single GPU, 2=dual GPU, etc.)"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose logging"),
     create_db: bool = typer.Option(False, "--create-db", help="Create database if it doesn't exist"),
     start_ray_head: bool = typer.Option(False, "--start-ray-head", help="Start Ray head if no cluster is found"),
@@ -137,11 +137,14 @@ def optimize_command(
             raise typer.Exit(1)
         
         # Run optimization
+        # Use CLI value or fall back to YAML config
+        final_max_concurrent = max_concurrent or study_config.optimization.max_concurrent
+        
         run_optimization_sync(
             execution_backend, 
             study_config, 
             n_trials, 
-            max_concurrent,
+            final_max_concurrent,
             create_db
         )
         
@@ -571,7 +574,7 @@ def resume_command(
     backend: str = typer.Option("ray", "--backend", "-b", help="Execution backend: 'ray' (only supported option)"),
     n_trials: Optional[int] = typer.Option(None, "--trials", "-n", help="Number of additional trials to run"),
     n_total_trials: Optional[int] = typer.Option(None, "--total-trials", help="Total number of trials to reach (overrides config)"),
-    max_concurrent: Optional[int] = typer.Option(None, "--max-concurrent", help="Max concurrent trials"),
+    max_concurrent: Optional[int] = typer.Option(None, "--max-concurrent", help="REQUIRED: Max concurrent trials (1=single GPU, 2=dual GPU, etc.)"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose logging"),
     start_ray_head: bool = typer.Option(False, "--start-ray-head", help="Start Ray head if no cluster is found"),
     python_executable: Optional[str] = typer.Option(None, "--python-executable", help="Explicit Python executable path for Ray workers"),
@@ -620,7 +623,9 @@ def resume_command(
             raise typer.Exit(1)
         
         # Resume study
-        resume_study_sync(execution_backend, study_config, n_trials, n_total_trials, max_concurrent)
+        # Use CLI value or fall back to YAML config
+        final_max_concurrent = max_concurrent or study_config.optimization.max_concurrent
+        resume_study_sync(execution_backend, study_config, n_trials, n_total_trials, final_max_concurrent)
         
     except Exception as e:
         console.print(f"[bold red]Resume failed: {e}[/bold red]")

--- a/auto_tune_vllm/core/study_controller.py
+++ b/auto_tune_vllm/core/study_controller.py
@@ -368,7 +368,7 @@ class StudyController:
         for values in search_space.values():
             size *= len(values)
         return size
-    
+        
     def run_optimization(
         self, 
         n_trials: Optional[int] = None,
@@ -387,7 +387,16 @@ class StudyController:
             Completed Optuna study
         """
         total_trials = n_trials or self.config.optimization.n_trials
-        max_concurrent = max_concurrent or float('inf')
+        
+        # Require explicit concurrency specification
+        if max_concurrent is None:
+            raise ValueError(
+                "❌ --max-concurrent is required to prevent GPU memory conflicts!\n\n"
+                "Add to your YAML config:\n"
+                "  optimization:\n"
+                "    max_concurrent: 2  # Match your GPU count\n\n"
+                "Or use CLI: --max-concurrent 2"
+            )
         
         logger.info(f"Starting optimization: {total_trials} trials, "
                    f"max concurrent: {max_concurrent if max_concurrent != float('inf') else 'unlimited'}")

--- a/auto_tune_vllm/core/study_controller.py
+++ b/auto_tune_vllm/core/study_controller.py
@@ -388,15 +388,19 @@ class StudyController:
         """
         total_trials = n_trials or self.config.optimization.n_trials
         
-        # Require explicit concurrency specification
+        # Require explicit, positive concurrency specification
         if max_concurrent is None:
-            raise ValueError(
+            msg = (
                 "❌ --max-concurrent is required to prevent GPU memory conflicts!\n\n"
                 "Add to your YAML config:\n"
                 "  optimization:\n"
                 "    max_concurrent: 2  # Match your GPU count\n\n"
                 "Or use CLI: --max-concurrent 2"
             )
+            raise ValueError(msg)
+        if max_concurrent < 1:
+            raise ValueError("--max-concurrent must be >= 1")
+
         
         logger.info(f"Starting optimization: {total_trials} trials, "
                    f"max concurrent: {max_concurrent if max_concurrent != float('inf') else 'unlimited'}")

--- a/auto_tune_vllm/execution/trial_controller.py
+++ b/auto_tune_vllm/execution/trial_controller.py
@@ -231,6 +231,13 @@ class BaseTrialController(TrialController):
             if hasattr(self.benchmark_provider, 'set_logger'):
                 self.benchmark_provider.set_logger(benchmark_logger)
             
+            # Pass trial context for benchmark result storage
+            if hasattr(self.benchmark_provider, 'set_trial_context'):
+                self.benchmark_provider.set_trial_context(
+                    trial_config.study_name, 
+                    trial_config.trial_id
+                )
+            
             benchmark_result = self.benchmark_provider.run_benchmark(
                 model_url=server_info["url"],
                 config=trial_config.benchmark_config

--- a/auto_tune_vllm/schemas/v0_10_0.yaml
+++ b/auto_tune_vllm/schemas/v0_10_0.yaml
@@ -45,11 +45,6 @@ parameters:
     default: []  # vLLM default: empty list (disabled)
     description: "CUDA graph capture sizes"
     
-  enable_cuda_graphs:
-    type: "boolean"
-    data_type: "bool"
-    default: false  # Inferred from empty cuda_graph_sizes default
-    description: "Enable CUDA graph optimization"
     
   # Prefill optimization
   long_prefill_token_threshold:
@@ -106,7 +101,7 @@ parameters:
   preemption_mode:
     type: "list"
     data_type: "str"
-    options: ["recompute", "swap", null]
+    options: ["recompute", "swap"]
     default: null  # Determined automatically based on use case
     description: "Preemption strategy for memory management"
     

--- a/auto_tune_vllm/schemas/v0_10_0.yaml
+++ b/auto_tune_vllm/schemas/v0_10_0.yaml
@@ -1,0 +1,166 @@
+# vLLM 0.10.0 Parameter Schema with Optimization Ranges and Defaults
+# This file contains both optimization ranges and vLLM default values
+version: "0.10.0"
+
+parameters:
+  # Core performance parameters
+  max_num_batched_tokens:
+    type: "range"
+    data_type: "int"
+    min: 1024
+    max: 96000
+    step: 1024
+    default: null  # vLLM auto-calculates based on model and memory
+    description: "Maximum tokens processed in a single batch"
+    
+  gpu_memory_utilization:
+    type: "range"
+    data_type: "float" 
+    min: 0.70
+    max: 0.95
+    step: 0.01
+    default: 0.9  # vLLM default from cacheconfig
+    description: "GPU memory usage ratio"
+    
+  block_size:
+    type: "list"
+    data_type: "int"
+    options: [1, 8, 16, 32, 64, 128]
+    default: null  # No static default - determined by platform
+    description: "Memory block size for attention"
+    
+  # Cache and memory parameters
+  kv_cache_dtype:
+    type: "list"
+    data_type: "str"
+    options: ["auto", "fp8", "fp8_e4m3", "fp8_e5m2", "fp8_inc"]
+    default: "auto"  # vLLM default from cacheconfig
+    description: "Key-value cache data type"
+    
+  # CUDA graph optimization
+  cuda_graph_sizes:
+    type: "list"
+    data_type: "int"
+    options: [1000, 2000, 3000, 4000, 5000, 6000, 8000]
+    default: []  # vLLM default: empty list (disabled)
+    description: "CUDA graph capture sizes"
+    
+  enable_cuda_graphs:
+    type: "boolean"
+    data_type: "bool"
+    default: false  # Inferred from empty cuda_graph_sizes default
+    description: "Enable CUDA graph optimization"
+    
+  # Prefill optimization
+  long_prefill_token_threshold:
+    type: "list"
+    data_type: "int"
+    options: [0, 256, 512, 1024, 2048, 4096, 8192, 11500]
+    default: 0  # vLLM default from schedulerconfig
+    description: "Threshold for long prefill tokens"
+    
+  max_seq_len_to_capture:
+    type: "list"
+    data_type: "int"
+    options: [4096, 8192, 12288, 16384]
+    default: 8192  # vLLM default from modelconfig
+    description: "Maximum sequence length for CUDA graphs"
+    
+  max_num_partial_prefills:
+    type: "list"
+    data_type: "int"
+    options: [1, 2, 4, 8]
+    default: 1  # vLLM default from schedulerconfig
+    description: "Maximum partial prefill operations"
+    
+  # Parallelism parameters
+  tensor_parallel_size:
+    type: "list"
+    data_type: "int"
+    options: [1, 2, 4, 8]
+    default: 1  # vLLM default from parallelconfig
+    description: "Number of tensor parallel groups (GPUs for tensor parallelism)"
+    
+  pipeline_parallel_size:
+    type: "list" 
+    data_type: "int"
+    options: [1, 2, 4]
+    default: 1  # vLLM default from parallelconfig
+    description: "Number of pipeline parallel stages"
+    
+  data_parallel_size:
+    type: "list"
+    data_type: "int" 
+    options: [1, 2, 4]
+    default: 1  # vLLM default from parallelconfig
+    description: "Number of data parallel replicas"
+    
+  # Caching features
+  enable_prefix_caching:
+    type: "boolean" 
+    data_type: "bool"
+    default: null  # No static default in v0.10.0
+    description: "Enable prefix caching"
+    
+  # Scheduling parameters
+  preemption_mode:
+    type: "list"
+    data_type: "str"
+    options: ["recompute", "swap", null]
+    default: null  # Determined automatically based on use case
+    description: "Preemption strategy for memory management"
+    
+  # Additional cache parameters
+  swap_space:
+    type: "range"
+    data_type: "int"
+    min: 0
+    max: 16
+    step: 1
+    default: 4  # vLLM default from cacheconfig
+    description: "CPU swap space in GB"
+    
+  cpu_offload_gb:
+    type: "range"
+    data_type: "int"
+    min: 0
+    max: 64
+    step: 4
+    default: 0  # vLLM default from cacheconfig
+    description: "CPU offload memory in GB"
+
+# vLLM CLI defaults for reference (extracted from v0.10.0)
+vllm_defaults:
+  cacheconfig:
+    block_size: null  # No static default - set by platform
+    calculate_kv_scales: false
+    cpu_offload_gb: 0
+    gpu_memory_utilization: 0.9
+    kv_cache_dtype: "auto"
+    prefix_caching_hash_algo: "builtin"
+    swap_space: 4
+  
+  modelconfig:
+    dtype: "auto"
+    enforce_eager: false
+    max_seq_len_to_capture: 8192
+    
+  parallelconfig:
+    data_parallel_backend: "mp"
+    data_parallel_size: 1
+    disable_custom_all_reduce: false
+    pipeline_parallel_size: 1
+    tensor_parallel_size: 1
+    
+  schedulerconfig:
+    async_scheduling: false
+    cuda_graph_sizes: []
+    enable_chunked_prefill: null  # No static default
+    long_prefill_token_threshold: 0
+    max_long_partial_prefills: 1
+    max_num_batched_tokens: null  # No static default
+    max_num_partial_prefills: 1
+    max_num_seqs: null  # No static default
+    preemption_mode: null  # Determined automatically
+    scheduler_delay_factor: 0.0
+    scheduling_policy: "fcfs"

--- a/auto_tune_vllm/schemas/vllm_defaults/v0_10_0.yaml
+++ b/auto_tune_vllm/schemas/vllm_defaults/v0_10_0.yaml
@@ -1,0 +1,68 @@
+# vLLM CLI defaults extracted automatically
+# vLLM version: 0.10.0
+# Generated sections: cacheconfig, schedulerconfig, modelconfig, parallelconfig
+# This file contains default values from vLLM CLI arguments
+# Use this instead of hardcoding defaults in Python code
+
+defaults:
+  cacheconfig:
+    calculate_kv_scales: false
+    cpu_offload_gb: 0
+    gpu_memory_utilization: 0.9
+    kv_cache_dtype: auto
+    prefix_caching_hash_algo: builtin
+    swap_space: 4
+  modelconfig:
+    allowed_local_media_path: ''
+    config_format: auto
+    convert: auto
+    disable_async_output_proc: false
+    disable_cascade_attn: false
+    disable_sliding_window: false
+    dtype: auto
+    enable_prompt_embeds: false
+    enable_sleep_mode: false
+    enforce_eager: false
+    generation_config: auto
+    hf_overrides: {}
+    logprobs_mode: raw_logprobs
+    max_logprobs: 20
+    max_seq_len_to_capture: 8192
+    model_impl: auto
+    override_generation_config: {}
+    override_neuron_config: {}
+    rope_scaling: {}
+    runner: auto
+    skip_tokenizer_init: false
+    tokenizer_mode: auto
+    trust_remote_code: false
+  parallelconfig:
+    data_parallel_backend: mp
+    data_parallel_hybrid_lb: false
+    data_parallel_size: 1
+    disable_custom_all_reduce: false
+    enable_eplb: false
+    enable_expert_parallel: false
+    enable_multimodal_encoder_data_parallel: false
+    eplb_log_balancedness: false
+    eplb_step_interval: 3000
+    eplb_window_size: 1000
+    num_redundant_experts: 0
+    pipeline_parallel_size: 1
+    ray_workers_use_nsight: false
+    tensor_parallel_size: 1
+    worker_cls: auto
+    worker_extension_cls: ''
+  schedulerconfig:
+    async_scheduling: false
+    cuda_graph_sizes: []
+    disable_chunked_mm_input: false
+    disable_hybrid_kv_cache_manager: false
+    long_prefill_token_threshold: 0
+    max_long_partial_prefills: 1
+    max_num_partial_prefills: 1
+    num_lookahead_slots: 0
+    scheduler_cls: vllm.core.scheduler.Scheduler
+    scheduler_delay_factor: 0.0
+    scheduling_policy: fcfs
+version: 0.10.0

--- a/auto_tune_vllm/utils/vllm_cli_parser.py
+++ b/auto_tune_vllm/utils/vllm_cli_parser.py
@@ -356,8 +356,6 @@ class VLLMCLIParser:
                      param_def["type"] = "range"
                      param_def["data_type"] = "float"
                      if arg.default_value is not None:
--                        param_def["min"] = max(0.0, arg.default_value - 1.0)
--                        param_def["max"] = min(1.0, arg.default_value + 1.0)
                         dv = float(arg.default_value)
                         if 0.0 <= dv <= 1.0:
                             param_def["min"] = max(0.0, dv - 0.1)
@@ -492,18 +490,18 @@ class VLLMCLIParser:
         Returns:
             Default value or None if not found
         """
-     def get_parameter_defaults(self, param_name: str) -> Any:
+        
+    def get_parameter_defaults(self, param_name: str) -> Any:
         # Ensure the CLI has been parsed so self.arguments is populated
         if not self.arguments:
             self.parse()
-         # Normalize parameter name
-         if not param_name.startswith('--'):
-             param_name = '--' + param_name.replace('_', '-')
-         
-         if param_name in self.arguments:
-             return self.arguments[param_name].default_value
-         
-         return None
+        # Normalize parameter name
+        if not param_name.startswith('--'):
+            param_name = '--' + param_name.replace('_', '-')
+        
+        if param_name in self.arguments:
+            return self.arguments[param_name].default_value
+        return None
 
 
 def main():

--- a/auto_tune_vllm/utils/vllm_cli_parser.py
+++ b/auto_tune_vllm/utils/vllm_cli_parser.py
@@ -490,17 +490,16 @@ class VLLMCLIParser:
         Returns:
             Default value or None if not found
         """
-        
-    def get_parameter_defaults(self, param_name: str) -> Any:
         # Ensure the CLI has been parsed so self.arguments is populated
         if not self.arguments:
             self.parse()
-        # Normalize parameter name
+         # Normalize parameter name
         if not param_name.startswith('--'):
             param_name = '--' + param_name.replace('_', '-')
         
         if param_name in self.arguments:
             return self.arguments[param_name].default_value
+        
         return None
 
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -148,7 +148,7 @@ Use an existing Ray cluster (recommended if one is already running):
 auto-tune-vllm optimize \
   --config examples/study_config_local_exec.yaml \
   --venv-path "$(pwd)/venv" \
-  --max-concurrent <gpu_count>
+  --max-concurrent <count>
 ```
 
 Start a new Ray head locally (when no cluster is running):
@@ -157,7 +157,7 @@ Start a new Ray head locally (when no cluster is running):
 auto-tune-vllm optimize \
   --config examples/study_config_local_exec.yaml \
   --venv-path "$(pwd)/venv" \
-  --max-concurrent <gpu_count> \
+  --max-concurrent <count> \
   --start-ray-head
 ```
 
@@ -223,7 +223,7 @@ You can now explore optimization history, parameter importance, and parallel coo
     ray stop --force
     ray start --head --dashboard-host=0.0.0.0
     ```
-- **Important**: Add `--max-concurrent <gpu_count>` or set `max_concurrent: <gpu_count>` in your YAML config.
+- **Important**: Add `--max-concurrent <count>` or set `max_concurrent: <count>` in your YAML config.
 
 ### Next Steps
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -121,7 +121,7 @@ parameters:
 ```
 
 **To customize optimization ranges** (for better results after initial studies):
-- Edit `auto_tune_vllm/schemas/v0_10_1_1.yaml` 
+- Edit `auto_tune_vllm/schemas/v0_10_1_1.yaml` or `auto_tune_vllm/schemas/v0_10_0_0.yaml`
 - Narrow ranges around promising values from previous runs
 - **Don't change the `default` values** - only adjust `min`/`max`/`options`
 
@@ -147,7 +147,8 @@ Use an existing Ray cluster (recommended if one is already running):
 ```bash
 auto-tune-vllm optimize \
   --config examples/study_config_local_exec.yaml \
-  --venv-path "$(pwd)/venv"
+  --venv-path "$(pwd)/venv" \
+  --max-concurrent <gpu_count>
 ```
 
 Start a new Ray head locally (when no cluster is running):
@@ -156,6 +157,7 @@ Start a new Ray head locally (when no cluster is running):
 auto-tune-vllm optimize \
   --config examples/study_config_local_exec.yaml \
   --venv-path "$(pwd)/venv" \
+  --max-concurrent <gpu_count> \
   --start-ray-head
 ```
 
@@ -177,7 +179,7 @@ auto-tune-vllm logs --study-id <your_study_id> --log-path ./logs
 If you configured PostgreSQL logging:
 
 ```bash
-auto-tune-vllm logs --study-id <your_study_id> --database-url postgresql://user:pass@host:5432/db
+auto-tune-vllm logs --study-name <your_study_name> --database-url postgresql://user:pass@host:5432/db
 ```
 
 > See [Logging Configuration](configuration.md#logging-configuration) for detailed logging options.
@@ -221,6 +223,7 @@ You can now explore optimization history, parameter importance, and parallel coo
     ray stop --force
     ray start --head --dashboard-host=0.0.0.0
     ```
+- **Important**: Add `--max-concurrent <gpu_count>` or set `max_concurrent: <gpu_count>` in your YAML config.
 
 ### Next Steps
 

--- a/examples/study_config_local_exec.yaml
+++ b/examples/study_config_local_exec.yaml
@@ -1,6 +1,6 @@
 # Example study configuration with auto-generated study name
 study:
-  # name: "local_single_trial_test_3"  # <- Comment out to use auto-generation
+  name: "study_6_increased_range_batched_tokens"  # <- Comment out to use auto-generation
   # Will auto-generate unique name like: study_123456
   # No database - will use local SQLite storage in temp folder
   
@@ -14,41 +14,45 @@ optimization:
   # # sampler: "tpe"
   # n_trials: 1
   
-  # Alternative: Use preset for common configurations
-  preset: "high_throughput" 
-  # options are: high_throughput, low_latency, balanced
-
-  # Alternative: Multi-objective (throughput vs latency)
-  # approach: "multi_objective"
-  # objectives:
-  #   - metric: "output_tokens_per_second"
-  #     direction: "maximize"
-  #     percentile: "mean"
-  #   - metric: "request_latency"
-  #     direction: "minimize"
-  #     percentile: "median"
-  sampler: "botorch"
-  n_trials: 200
+  # Multi-objective optimization: throughput vs latency trade-offs
+  approach: "multi_objective"
+  objectives:
+    - metric: "output_tokens_per_second"
+      direction: "maximize"
+      percentile: "mean"
+    - metric: "request_latency"
+      direction: "minimize"
+      percentile: "median"
+  sampler: "nsga2"  # Perfect for multi-objective
+  n_trials: 800  # More trials = better exploration (NSGA2 improves over time)
+  # max_concurrent: 2  # REQUIRED: Set to your GPU count (prevents memory conflicts)
+  # Note: NSGA2 doesn't use startup trials - it explores throughout the run 
   
 benchmark:
   benchmark_type: "guidellm"
-  model: "RedHatAI/Qwen3-1.7B-FP8-dynamic"  
-  max_seconds: 240                 
+  model: "RedHatAI/Qwen3-30B-A3B-FP8-dynamic"  #MoE
+  max_seconds: 300                 
   dataset: null  # Use synthetic data
-  prompt_tokens: 2000   
-  output_tokens: 2000
-  rate: 30             
+  prompt_tokens: 10000   
+  output_tokens: 1000
+  rate: 10             
   
 logging:
   file_path: "/tmp/auto-tune-vllm-local-run/logs"  # Local temp folder
   log_level: "INFO"
 
-
+baseline:
+  enabled: true
+  run_first: true
+  concurrency_levels: [10]
   
 parameters:
   max_num_batched_tokens:
     enabled: true
     # Uses schema defaults
+    min: 11500
+    max: 96000
+    step: 1024
     
   gpu_memory_utilization:
     enabled: true
@@ -58,7 +62,30 @@ parameters:
     
   kv_cache_dtype:
     enabled: true
-    options: ["auto", "fp8"]
+    options: ["fp8"]
     
-  enable_cuda_graphs:
-    enabled: false
+  block_size:
+    enabled: true
+    options: [8, 16, 32]
+
+  cuda_graph_sizes:
+    enabled: true
+    min: 8
+    max: 8192
+    step: 128
+    
+  long_prefill_token_threshold:
+    enabled: true
+    min: 0
+    max: 11500
+    step: 256
+
+  max_num_partial_prefills:
+    enabled: true
+    options: [1, 2, 4, 8]
+
+  max_seq_len_to_capture: 
+    enabled: true
+    min: 4096
+    max: 16384
+    step: 1024

--- a/examples/study_config_local_exec.yaml
+++ b/examples/study_config_local_exec.yaml
@@ -1,33 +1,23 @@
 # Example study configuration with auto-generated study name
 study:
-  name: "study_6_increased_range_batched_tokens"  # <- Comment out to use auto-generation
+  name: "local_single_trial_test_3"  # <- Comment out to use auto-generation
   # Will auto-generate unique name like: study_123456
   # No database - will use local SQLite storage in temp folder
   
 optimization:
   # High-throughput optimization: Maximize token generation rate
-  # approach: "single_objective"
+  # approach: "single_objective" or "multi_objective"
   # objective:
   #   metric: "output_tokens_per_second"  # Throughput optimization
   #   direction: "maximize"
   #   percentile: "mean"  # Use median for stable results
-  # # sampler: "tpe"
-  # n_trials: 1
-  
-  # Multi-objective optimization: throughput vs latency trade-offs
-  approach: "multi_objective"
-  objectives:
-    - metric: "output_tokens_per_second"
-      direction: "maximize"
-      percentile: "mean"
-    - metric: "request_latency"
-      direction: "minimize"
-      percentile: "median"
-  sampler: "nsga2"  # Perfect for multi-objective
-  n_trials: 800  # More trials = better exploration (NSGA2 improves over time)
-  # max_concurrent: 2  # REQUIRED: Set to your GPU count (prevents memory conflicts)
-  # Note: NSGA2 doesn't use startup trials - it explores throughout the run 
-  
+  # # sampler: "botorch"
+  # n_trials: 200
+  preset: "high_throughput"
+  sampler: "botorch"
+  n_trials: 200
+  max_concurrent: 2  
+
 benchmark:
   benchmark_type: "guidellm"
   model: "RedHatAI/Qwen3-30B-A3B-FP8-dynamic"  #MoE
@@ -46,12 +36,11 @@ baseline:
   run_first: true
   concurrency_levels: [10]
   
-parameters:
+parameters: # parameters to optimize
   max_num_batched_tokens:
     enabled: true
-    # Uses schema defaults
-    min: 11500
-    max: 96000
+    min: 1024
+    max: 32768 
     step: 1024
     
   gpu_memory_utilization:
@@ -76,10 +65,8 @@ parameters:
     
   long_prefill_token_threshold:
     enabled: true
-    min: 0
-    max: 11500
-    step: 256
-
+    options: [0, 256, 512, 1024, 2048, 4096, 8192, 11500] 
+    
   max_num_partial_prefills:
     enabled: true
     options: [1, 2, 4, 8]

--- a/examples/study_config_local_exec.yaml
+++ b/examples/study_config_local_exec.yaml
@@ -20,7 +20,7 @@ optimization:
 
 benchmark:
   benchmark_type: "guidellm"
-  model: "RedHatAI/Qwen3-30B-A3B-FP8-dynamic"  #MoE
+  model: "RedHatAI/Qwen3-30B-A3B-FP8-dynamic" 
   max_seconds: 300                 
   dataset: null  # Use synthetic data
   prompt_tokens: 10000   

--- a/src/serving/run_baseline.py
+++ b/src/serving/run_baseline.py
@@ -39,10 +39,8 @@ def run_baseline_test(model=None, max_seconds=None, prompt_tokens=None, output_t
     
     # Add baseline-specific flags to manage memory usage
     baseline_flags = [
-        "--gpu-memory-utilization", "0.85",  # Use 85% of GPU memory instead of default 90%
-        "--max-num-seqs", str(concurrency),   # Limit concurrent sequences
-        "--disable-sliding-window",           # Disable sliding window to save memory
-        "--enforce-eager"                     # Use eager execution to avoid compilation overhead
+
+        "--max-num-seqs", str(concurrency),   # Limit concurrent sequencesoverhead
     ]
     
     vllm_cmd = build_vllm_command(model_name=model, port=port, candidate_flags=baseline_flags)


### PR DESCRIPTION
-Add benchmark result preservation to study directories.
-Preserve GuideLLM benchmark results in permanent files for post-analysis and debugging

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Add configurable max concurrency for trials via CLI/YAML with validation.
  - Auto-detect vLLM version to load the appropriate parameter schema.
  - Persist benchmark results per trial for easier retrieval.
  - Update default benchmark model to a Red Hat–hosted variant.

- Bug Fixes
  - Improve CLI defaults parsing and float range derivation.

- Documentation
  - Update README and Quick Start to use --max-concurrent and --study-name.
  - Add guidance on configuring concurrency.

- Chores
  - Add vLLM 0.10.0 schema and defaults.
  - Refresh example study config with broader tuning options.
  - Simplify baseline serving flags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->