### PR TITLE
Add benchmark result preservation to study directories

### DIFF
--- a/auto_tune_vllm/execution/trial_controller.py
+++ b/auto_tune_vllm/execution/trial_controller.py
@@ -231,6 +231,13 @@ class BaseTrialController(TrialController):
             if hasattr(self.benchmark_provider, 'set_logger'):
                 self.benchmark_provider.set_logger(benchmark_logger)
             
+            # Pass trial context for benchmark result storage
+            if hasattr(self.benchmark_provider, 'set_trial_context'):
+                self.benchmark_provider.set_trial_context(
+                    trial_config.study_name, 
+                    trial_config.trial_id
+                )
+            
             benchmark_result = self.benchmark_provider.run_benchmark(
                 model_url=server_info["url"],
                 config=trial_config.benchmark_config


### PR DESCRIPTION
Preserve GuideLLM benchmark results in permanent files for post-analysis and debugging

- Added trial context tracking in BenchmarkProvider base class
- Implemented _preserve_results_file() method in GuideLLMBenchmark
- Modified trial controller to pass trial context to benchmark providers
- Results saved to /tmp/auto-tune-vllm-local-run/logs/{study_name}/benchmark_results/