### PR TITLE
feat: Enable Ray auto-start by default

### DIFF
--- a/auto_tune_vllm/cli/main.py
+++ b/auto_tune_vllm/cli/main.py
@@ -72,7 +72,7 @@ def optimize_command(
     max_concurrent: Optional[int] = typer.Option(None, "--max-concurrent", help="REQUIRED: Max concurrent trials to run simultaneously."),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose logging"),
     create_db: bool = typer.Option(False, "--create-db", help="Create database if it doesn't exist"),
-    start_ray_head: bool = typer.Option(False, "--start-ray-head", help="Start Ray head if no cluster is found"),
+    start_ray_head: bool = typer.Option(True, "--start-ray-head/--no-start-ray-head", help="Start Ray head if no cluster is found (default: True)"),
     python_executable: Optional[str] = typer.Option(None, "--python-executable", help="Explicit Python executable path for Ray workers"),
     venv_path: Optional[str] = typer.Option(None, "--venv-path", help="Virtual environment path for Ray workers"),
     conda_env: Optional[str] = typer.Option(None, "--conda-env", help="Conda environment name for Ray workers"),
@@ -128,7 +128,9 @@ def optimize_command(
             )
             console.print("[blue]Using Ray distributed execution[/blue]")
             if start_ray_head:
-                console.print("[blue]Will start Ray head if no cluster found[/blue]")
+                console.print("[blue]Will auto-start Ray head if no cluster found[/blue]")
+            else:
+                console.print("[yellow]Ray auto-start disabled - requires existing cluster[/yellow]")
         else:
             console.print("[bold red]Error: Local execution backend is not supported in this version.[/bold red]")
             console.print("[bold red]Only Ray distributed execution is available.[/bold red]")
@@ -583,7 +585,7 @@ def resume_command(
     n_total_trials: Optional[int] = typer.Option(None, "--total-trials", help="Total number of trials to reach (overrides config)"),
     max_concurrent: Optional[int] = typer.Option(None, "--max-concurrent", help="REQUIRED: Max concurrent trials to run simultaneously (should match your GPU count)"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose logging"),
-    start_ray_head: bool = typer.Option(False, "--start-ray-head", help="Start Ray head if no cluster is found"),
+    start_ray_head: bool = typer.Option(True, "--start-ray-head/--no-start-ray-head", help="Start Ray head if no cluster is found (default: True)"),
     python_executable: Optional[str] = typer.Option(None, "--python-executable", help="Explicit Python executable path for Ray workers"),
     venv_path: Optional[str] = typer.Option(None, "--venv-path", help="Virtual environment path for Ray workers"),
     conda_env: Optional[str] = typer.Option(None, "--conda-env", help="Conda environment name for Ray workers"),
@@ -620,7 +622,9 @@ def resume_command(
             )
             console.print("[blue]Using Ray distributed execution[/blue]")
             if start_ray_head:
-                console.print("[blue]Will start Ray head if no cluster found[/blue]")
+                console.print("[blue]Will auto-start Ray head if no cluster found[/blue]")
+            else:
+                console.print("[yellow]Ray auto-start disabled - requires existing cluster[/yellow]")
       
         else:
             console.print("[bold red]Error: Local execution backend is not supported in this version.[/bold red]")

--- a/auto_tune_vllm/execution/backends.py
+++ b/auto_tune_vllm/execution/backends.py
@@ -58,7 +58,7 @@ class RayExecutionBackend(ExecutionBackend):
     def __init__(
         self, 
         resource_requirements: Optional[Dict[str, float]] = None, 
-        start_ray_head: bool = False,
+        start_ray_head: bool = True,
         python_executable: Optional[str] = None,
         venv_path: Optional[str] = None,
         conda_env: Optional[str] = None

--- a/docs/ray_auto_start.md
+++ b/docs/ray_auto_start.md
@@ -2,29 +2,32 @@
 
 ## Overview
 
-The `--start-ray-head` option allows auto-tune-vllm to automatically start a Ray head node when no existing Ray cluster is detected. This simplifies deployment for single-machine setups and development environments.
+Auto-tune-vllm automatically starts a Ray head node when no existing Ray cluster is detected. This simplifies deployment for single-machine setups and development environments. Ray auto-start is **enabled by default**.
 
 ## Usage
 
 ```bash
-# Auto-start Ray head if no cluster found
-auto-tune-vllm optimize --config study.yaml --backend ray --start-ray-head
-
-# Traditional usage (requires existing Ray cluster)
+# Default behavior - auto-start Ray head if no cluster found
 auto-tune-vllm optimize --config study.yaml --backend ray
+
+# Disable auto-start (requires existing Ray cluster)
+auto-tune-vllm optimize --config study.yaml --backend ray --no-start-ray-head
+
+# Explicitly enable auto-start (same as default)
+auto-tune-vllm optimize --config study.yaml --backend ray --start-ray-head
 ```
 
 ## How It Works
 
 1. **Detection**: When using Ray backend, the system first attempts to connect to an existing Ray cluster
-2. **Fallback**: If no cluster is found and `--start-ray-head` is enabled, automatically starts a Ray head
+2. **Fallback**: If no cluster is found and auto-start is enabled (default), automatically starts a Ray head
 3. **Connection**: Connects to the newly started Ray head using auto-discovery
 4. **Cleanup**: Automatically stops the Ray head when optimization completes
 
 ## Technical Implementation
 
 ### CLI Changes
-- Added `--start-ray-head` boolean option to the `optimize` command
+- `--start-ray-head` is enabled by default (use `--no-start-ray-head` to disable)
 - Option is passed to `RayExecutionBackend` constructor
 
 ### Backend Changes
@@ -40,14 +43,14 @@ When auto-starting, the Ray head is configured with:
 - Connection: Uses Ray's auto-discovery mechanism
 ## Error Handling
 
-### Without `--start-ray-head`
+### With `--no-start-ray-head` (auto-start disabled)
 ```
 Failed to connect to Ray cluster: [connection error]
 Use --start-ray-head to automatically start a Ray head, or start one manually:
   ray start --head
 ```
 
-### With `--start-ray-head`
+### With auto-start enabled (default)
 - Automatically attempts to start Ray head
 - Provides detailed error messages if Ray head startup fails
 - Graceful cleanup on both success and failure
@@ -69,20 +72,20 @@ INFO: Successfully stopped Ray head
 
 ### Development Environment
 ```bash
-# Quick start for local development
-auto-tune-vllm optimize --config dev-study.yaml --start-ray-head
+# Quick start for local development (auto-start enabled by default)
+auto-tune-vllm optimize --config dev-study.yaml
 ```
 
 ### Single Machine Deployment
 ```bash
-# Production single-machine setup
-auto-tune-vllm optimize --config production.yaml --backend ray --start-ray-head
+# Production single-machine setup (auto-start enabled by default)
+auto-tune-vllm optimize --config production.yaml --backend ray
 ```
 
 ### CI/CD Pipelines
 ```bash
-# Automated testing with ephemeral Ray cluster
-auto-tune-vllm optimize --config test-study.yaml --start-ray-head --trials 5
+# Automated testing with ephemeral Ray cluster (auto-start enabled by default)
+auto-tune-vllm optimize --config test-study.yaml --trials 5
 ```
 
 ## Considerations


### PR DESCRIPTION
## Summary
Enable Ray auto-start by default to eliminate "no cluster found" errors on startup.

## Changes
- Change `RayExecutionBackend` default `start_ray_head` from `False` to `True`
- Update CLI options to use `--start-ray-head/--no-start-ray-head` pattern  
- Update documentation to reflect new default behavior

## Benefits
- Users can now run optimization without manually starting Ray cluster
- Use `--no-start-ray-head` to disable if existing cluster is preferred
