### PR TITLE
ADD: Support for static arguments for vLLM (basline+trials) and special arguments for baseline

### DIFF
--- a/auto_tune_vllm/core/config.py
+++ b/auto_tune_vllm/core/config.py
@@ -583,13 +583,22 @@ class ConfigValidator:
         # Validate static parameters (simple key-value pairs for vLLM CLI args)
         static_params = {}
         
-        for param_name, param_value in raw_config.get("static_parameters", {}).items():
+        raw_static_parameters = raw_config.get("static_parameters")
+        if raw_static_parameters is None:
+            raw_static_parameters = {}
+        elif not isinstance(raw_static_parameters, dict):
+            raise TypeError(
+                "Static parameters must be provided as a mapping of CLI flag names to simple values."
+            )
+
+        for param_name, param_value in raw_static_parameters.items():
             if not isinstance(param_value, (str, int, float, bool)):
-                raise ValueError(f"Static parameter '{param_name}' must be a simple value (string, number, or boolean), got {type(param_value)}")
+                raise ValueError(
+                    f"Static parameter '{param_name}' must be a simple value (string, number, or boolean), got {type(param_value)}"
+                )
             
             # Keep the original type (don't convert to string like env vars)
             static_params[param_name] = param_value
-        
         # Build other configs
         study_info = raw_config.get("study", {})
         if study_info is None:

--- a/auto_tune_vllm/core/config.py
+++ b/auto_tune_vllm/core/config.py
@@ -644,6 +644,10 @@ class ConfigValidator:
                 # Ensure parameters field is a dict, not None (YAML can parse empty as None)
                 if baseline_data.get("parameters") is None:
                     baseline_data["parameters"] = {}
+                elif not isinstance(baseline_data.get("parameters"), dict):
+                    raise TypeError(
+                        "Baseline parameters must be provided as a mapping of CLI flag names to simple values."
+                    )
                 baseline_config = BaselineConfig(**baseline_data)
         
         return StudyConfig(


### PR DESCRIPTION
This would allow us to set vLLM arguments for both baseline and trials without having to edit any of the code

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for static parameters that apply to all trials; values retain native types and merge with trial and baseline settings.

- **Bug Fixes**
  - Baseline handling hardened: ensures baseline parameters exist and conditionally adjusts max-num-seqs for high concurrency.

- **Documentation**
  - Expanded configuration guide with Static Parameters, updated Baseline Configuration, examples, environment variable guidance, and merge/override behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->