### PR TITLE
chore: add linting for main portion of auto_tune_vllm

### DIFF
--- a/auto_tune_vllm/benchmarks/providers.py
+++ b/auto_tune_vllm/benchmarks/providers.py
@@ -18,31 +18,28 @@ logger = logging.getLogger(__name__)
 
 class BenchmarkProvider(ABC):
     """Abstract benchmark provider interface."""
-    
+
     def __init__(self):
         self._logger = logger  # Default to module logger
         self._trial_context = None  # Store trial context for file paths
-    
+
     def set_logger(self, custom_logger):
         """Set a custom logger for this benchmark provider."""
         self._logger = custom_logger
-    
+
     def set_trial_context(self, study_name: str, trial_id: str):
         """Set trial context for benchmark result storage."""
-        self._trial_context = {
-            'study_name': study_name,
-            'trial_id': trial_id
-        }
-    
+        self._trial_context = {"study_name": study_name, "trial_id": trial_id}
+
     @abstractmethod
     def run_benchmark(self, model_url: str, config: BenchmarkConfig) -> Dict[str, Any]:
         """
         Run benchmark against model server.
-        
+
         Args:
             model_url: URL of the vLLM server (e.g., "http://localhost:8000/v1")
             config: Benchmark configuration
-            
+
         Returns:
             Dictionary with benchmark results. Must include metrics that can be
             converted to objective values for Optuna.
@@ -59,35 +56,41 @@ class GuideLLMBenchmark(BenchmarkProvider):
         "output_tokens_per_second": "total",
         "requests_per_second": "total",
         "tokens_per_second": "total",
-
         # Quality metrics - use 'successful' for performance characteristics
         "request_latency": "successful",
         "time_to_first_token_ms": "successful",
         "inter_token_latency_ms": "successful",
         "time_per_output_token_ms": "successful",
-
         # Count metrics - use 'successful'
         "output_token_count": "successful",
         "prompt_token_count": "successful",
         "request_concurrency": "successful",
     }
-    
+
     def run_benchmark(self, model_url: str, config: BenchmarkConfig) -> Dict[str, Any]:
         """Run GuideLLM benchmark."""
         self._logger.info(f"Starting GuideLLM benchmark for {config.model}")
-        
+
         # Create results file path directly in permanent location
         results_file = self._get_results_file_path()
-        
+
         try:
             # Build GuideLLM command
             cmd = self._build_guidellm_command(model_url, config, results_file)
             # Validate binary and basic inputs
             import shutil
+
             if shutil.which("guidellm") is None:
-                raise RuntimeError("GuideLLM CLI not found on PATH. Please install or provide the full path.")
-            if not (model_url.startswith("http://") or model_url.startswith("https://")):
-                raise ValueError(f"Invalid model_url: {model_url!r} (expected http/https)")
+                raise RuntimeError(
+                    "GuideLLM CLI not found on PATH. "
+                    "Please install or provide the full path."
+                )
+            if not (
+                model_url.startswith("http://") or model_url.startswith("https://")
+            ):
+                raise ValueError(
+                    f"Invalid model_url: {model_url!r} (expected http/https)"
+                )
 
             # Run GuideLLM
             self._logger.info(f"Running: {' '.join(cmd)}")
@@ -97,22 +100,24 @@ class GuideLLMBenchmark(BenchmarkProvider):
                 timeout=config.max_seconds + 120,  # Add buffer for setup/teardown
                 capture_output=True,
                 text=True,
-                check=True
+                check=True,
             )
-            
+
             # Log GuideLLM output for debugging
             if process.stdout:
                 self._logger.info(f"GuideLLM stdout:\n{process.stdout}")
             if process.stderr:
                 self._logger.warning(f"GuideLLM stderr:\n{process.stderr}")
-            
-            self._logger.debug(f"GuideLLM process completed with return code: {process.returncode}")
-            
+
+            self._logger.debug(
+                f"GuideLLM process completed with return code: {process.returncode}"
+            )
+
             self._logger.info("GuideLLM completed successfully")
-            
+
             # Parse results
             return self._parse_guidellm_results(results_file)
-            
+
         except subprocess.TimeoutExpired as e:
             raise RuntimeError(
                 f"GuideLLM benchmark timed out after {config.max_seconds + 120} seconds"
@@ -122,67 +127,82 @@ class GuideLLMBenchmark(BenchmarkProvider):
         except OSError as e:
             # e.g., FileNotFoundError for the CLI
             raise RuntimeError("Failed to execute GuideLLM CLI") from e
-    
+
     def _get_results_file_path(self) -> str:
-        """Get the permanent results file path, creating directory structure if needed."""
+        """
+        Get the permanent results file path, creating directory structure if needed.
+        """
         if self._trial_context is None:
             # Fallback to temporary file if no trial context
             self._logger.warning("No trial context set, using temporary file")
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False
+            ) as f:
                 return f.name
-        
+
         try:
-            # Create directory structure: /tmp/auto-tune-vllm-local-run/logs/{study_name}/benchmark_results/
-            study_name = self._trial_context['study_name']
-            trial_id = self._trial_context['trial_id']
-            
+            # Create directory structure:
+            # /tmp/auto-tune-vllm-local-run/logs/{study_name}/benchmark_results/
+            study_name = self._trial_context["study_name"]
+            trial_id = self._trial_context["trial_id"]
+
             # Use /tmp as base directory for consistency with existing log structure
             base_dir = Path("/tmp/auto-tune-vllm-local-run/logs")
             benchmark_dir = base_dir / study_name / "benchmark_results"
-            
+
             # Create directory if it doesn't exist
             benchmark_dir.mkdir(parents=True, exist_ok=True)
-            
+
             # Create permanent results file with trial-specific name
             permanent_file = benchmark_dir / f"{trial_id}_benchmark_results.json"
-            
+
             return str(permanent_file)
-            
+
         except Exception as e:
-            self._logger.warning(f"Failed to create permanent results path: {e}, using temporary file")
-            with tempfile.NamedTemporaryFile(mode='w', suffix='.json', delete=False) as f:
+            self._logger.warning(
+                f"Failed to create permanent results path: {e}, using temporary file"
+            )
+            with tempfile.NamedTemporaryFile(
+                mode="w", suffix=".json", delete=False
+            ) as f:
                 return f.name
-    
+
     def _build_guidellm_command(
-        self, 
-        model_url: str, 
-        config: BenchmarkConfig, 
-        results_file: str
+        self, model_url: str, config: BenchmarkConfig, results_file: str
     ) -> list[str]:
         """Build GuideLLM command arguments."""
         # Use processor if specified, otherwise default to model
         processor = config.processor if config.processor is not None else config.model
-        
+
         cmd = [
-            "guidellm", "benchmark",
-            "--target", model_url,
-            "--model", config.model,
-            "--processor", processor,
-            "--rate-type", "concurrent",
-            "--max-seconds", str(config.max_seconds),
-            "--rate", str(config.rate),
-            "--output-path", results_file
+            "guidellm",
+            "benchmark",
+            "--target",
+            model_url,
+            "--model",
+            config.model,
+            "--processor",
+            processor,
+            "--rate-type",
+            "concurrent",
+            "--max-seconds",
+            str(config.max_seconds),
+            "--rate",
+            str(config.rate),
+            "--output-path",
+            results_file,
         ]
-        
+
         # Add dataset or synthetic data configuration
         if config.use_synthetic_data:
             # Build data JSON object - only include statistical parameters if specified
             data_config = {
                 "prompt_tokens": config.prompt_tokens,
-                "output_tokens": config.output_tokens
+                "output_tokens": config.output_tokens,
             }
-            
-            # Only add statistical distribution parameters if they were explicitly specified
+
+            # Only add statistical distribution parameters if they were explicitly
+            # specified
             if config.prompt_tokens_stdev is not None:
                 data_config["prompt_tokens_stdev"] = config.prompt_tokens_stdev
             if config.prompt_tokens_min is not None:
@@ -195,10 +215,8 @@ class GuideLLMBenchmark(BenchmarkProvider):
                 data_config["output_tokens_min"] = config.output_tokens_min
             if config.output_tokens_max is not None:
                 data_config["output_tokens_max"] = config.output_tokens_max
-            
-            cmd.extend([
-                "--data", json.dumps(data_config)
-            ])
+
+            cmd.extend(["--data", json.dumps(data_config)])
         else:
             if config.dataset.startswith("hf://"):
                 # HuggingFace dataset
@@ -210,48 +228,53 @@ class GuideLLMBenchmark(BenchmarkProvider):
                     raise FileNotFoundError(f"Dataset file not found: {config.dataset}")
                 cmd.extend(["--data-type", "file", "--dataset", config.dataset])
         return cmd
-    
+
     def _parse_guidellm_results(self, results_file: str) -> Dict[str, Any]:
         """Parse GuideLLM JSON results."""
         if not os.path.exists(results_file):
             raise RuntimeError(f"GuideLLM results file not found: {results_file}")
-        
+
         try:
             with open(results_file) as f:
                 data = json.load(f)
         except json.JSONDecodeError as e:
             raise RuntimeError(f"Invalid JSON in results file: {e}")
-        
+
         # Extract benchmark data structure
         try:
             benchmarks = data["benchmarks"]
             if not benchmarks:
                 raise RuntimeError("No benchmark data found in results")
-            
+
             # Get first (and typically only) benchmark result
             benchmark_data = benchmarks[0]
             metrics = benchmark_data["metrics"]
-            
+
             # Extract key metrics with percentiles
             result = {}
-            
+
             required_metrics = [
                 "requests_per_second",
-                "request_latency", 
+                "request_latency",
                 "output_tokens_per_second",
                 "time_to_first_token_ms",
-                "inter_token_latency_ms"
+                "inter_token_latency_ms",
             ]
-            
+
             for metric_name in required_metrics:
                 if metric_name not in metrics:
                     # FAIL HARD - no fallbacks for missing metrics
-                    raise RuntimeError(f"Required metric '{metric_name}' not found in GuideLLM results")
+                    raise RuntimeError(
+                        f"Required metric '{metric_name}' not found in GuideLLM results"
+                    )
 
                 # Get the appropriate request category for this metric
                 category = self.METRIC_CATEGORIES.get(metric_name, "successful")
                 if metric_name not in self.METRIC_CATEGORIES:
-                    self._logger.warning(f"Unknown metric '{metric_name}', defaulting to 'successful' category")
+                    self._logger.warning(
+                        f"Unknown metric '{metric_name}', "
+                        f"defaulting to 'successful' category"
+                    )
 
                 # Validate that the category exists in the results
                 if category not in metrics[metric_name]:
@@ -263,7 +286,15 @@ class GuideLLMBenchmark(BenchmarkProvider):
                 metric_data = metrics[metric_name][category]
 
                 # Extract ALL statistical measures that GuideLLM provides
-                statistical_measures = ["mean", "median", "mode", "min", "max", "std_dev", "variance"]
+                statistical_measures = [
+                    "mean",
+                    "median",
+                    "mode",
+                    "min",
+                    "max",
+                    "std_dev",
+                    "variance",
+                ]
 
                 for measure in statistical_measures:
                     if measure in metric_data:
@@ -275,46 +306,48 @@ class GuideLLMBenchmark(BenchmarkProvider):
                     result[f"{metric_name}_{percentile}"] = value
 
                 # Store base metric as median for backward compatibility
-                result[metric_name] = metric_data.get("median", metric_data.get("mean", 0.0))
-            
+                result[metric_name] = metric_data.get(
+                    "median", metric_data.get("mean", 0.0)
+                )
+
             return result
-            
+
         except (KeyError, IndexError, TypeError) as e:
             raise RuntimeError(f"Invalid benchmark data structure: {e}")
 
 
 class CustomBenchmarkTemplate(BenchmarkProvider):
     """Template for implementing custom benchmark providers."""
-    
+
     def run_benchmark(self, model_url: str, config: BenchmarkConfig) -> Dict[str, Any]:
         """
         Template implementation for custom benchmarks.
-        
+
         Override this method to implement your custom benchmark logic.
         The returned dictionary should contain metrics that will be used
         to compute objective values for Optuna optimization.
         """
         # Example custom benchmark implementation:
-        
+
         # 1. Setup your benchmark client/tools
         # benchmark_client = YourBenchmarkTool(model_url)
-        
+
         # 2. Run your benchmark logic
         # benchmark_results = benchmark_client.run_test(
         #     duration=config.max_seconds,
         #     concurrency=config.concurrency,
         #     # ... other config parameters
         # )
-        
+
         # 3. Return structured results
         # The keys should be metric names, values should be numeric
         # Optuna will use these for optimization objectives
-        
+
         return {
             "throughput": 0.0,  # requests/second or tokens/second
             "latency_p95": 0.0,  # 95th percentile latency in ms
             "latency_mean": 0.0,  # mean latency in ms
-            "error_rate": 0.0,   # error percentage
+            "error_rate": 0.0,  # error percentage
             # Add any other metrics relevant to your benchmark
             # These will be stored in the detailed_metrics and can be
             # used for analysis and visualization
@@ -331,8 +364,11 @@ BENCHMARK_PROVIDERS = {
 def get_benchmark_provider(provider_name: str) -> BenchmarkProvider:
     """Get benchmark provider by name."""
     if provider_name not in BENCHMARK_PROVIDERS:
-        raise ValueError(f"Unknown benchmark provider: {provider_name}. "
-                        f"Available providers: {list(BENCHMARK_PROVIDERS.keys())}")
-    
+        raise ValueError(
+            f"Unknown benchmark provider: {provider_name}. "
+            f"Available providers: {list(BENCHMARK_PROVIDERS.keys())}"
+        )
+
     provider_class = BENCHMARK_PROVIDERS[provider_name]
     return provider_class()
+

--- a/auto_tune_vllm/cli/main.py
+++ b/auto_tune_vllm/cli/main.py
@@ -23,19 +23,19 @@ console = Console()
 app = typer.Typer(
     name="auto-tune-vllm",
     help="Distributed hyperparameter optimization for vLLM serving",
-    add_completion=False
+    add_completion=False,
 )
 
 
 def setup_logging(verbose: bool = False):
     """Setup logging with Rich handler."""
     log_level = logging.DEBUG if verbose else logging.INFO
-    
+
     logging.basicConfig(
         level=log_level,
         format="%(message)s",
         datefmt="[%X]",
-        handlers=[RichHandler(rich_tracebacks=True, console=console)]
+        handlers=[RichHandler(rich_tracebacks=True, console=console)],
     )
 
 
@@ -44,9 +44,11 @@ def save_config_to_study_folder(config_file_path: str, study_config: StudyConfig
     try:
         config_path = Path(config_file_path)
         if not config_path.exists():
-            console.print(f"[yellow]Warning: Config file not found: {config_file_path}[/yellow]")
+            console.print(
+                f"[yellow]Warning: Config file not found: {config_file_path}[/yellow]"
+            )
             return
-        
+
         # Determine study folder based on storage configuration
         if study_config.storage_file:
             # For SQLite storage, use the directory containing the database file
@@ -54,18 +56,20 @@ def save_config_to_study_folder(config_file_path: str, study_config: StudyConfig
         else:
             # For PostgreSQL or in-memory storage, create a default folder structure
             study_folder = Path("./optuna_studies") / study_config.study_name
-        
+
         # Ensure study folder exists
         study_folder.mkdir(parents=True, exist_ok=True)
-        
+
         # Copy config file to study folder
         dest_config_path = study_folder / "study_config.yaml"
         shutil.copy2(config_path, dest_config_path)
-        
+
         console.print(f"[green]📄 Saved study config to: {dest_config_path}[/green]")
-        
+
     except Exception as e:
-        console.print(f"[yellow]Warning: Failed to save config to study folder: {e}[/yellow]")
+        console.print(
+            f"[yellow]Warning: Failed to save config to study folder: {e}[/yellow]"
+        )
 
 
 def _display_log_viewing_instructions(config: StudyConfig):
@@ -73,61 +77,101 @@ def _display_log_viewing_instructions(config: StudyConfig):
     # Determine the correct logging database URL or file path
     log_database_url = None
     log_file_path = None
-    
+
     if config.logging_config:
         log_database_url = config.logging_config.get("database_url")
         log_file_path = config.logging_config.get("file_path")
-    
+
     # Default to main database if no specific logging config and database is available
     if not log_database_url and not log_file_path and config.database_url:
         log_database_url = config.database_url
     elif not log_database_url and not log_file_path and not config.database_url:
         # No PostgreSQL available - use file logging
         log_file_path = f"./logs/{config.study_name}"
-    
+
     # Display appropriate instructions using the unified logs command
     if log_file_path:
-        console.print(f"[blue]📋 View logs with: auto-tune-vllm logs --study-name {config.study_name} --log-path {log_file_path}[/blue]")
+        console.print(
+            f"[blue]📋 View logs with: auto-tune-vllm logs --study-name {config.study_name} --log-path {log_file_path}[/blue]"  # noqa: E501
+        )
     elif log_database_url:
-        console.print(f"[blue]📋 View logs with: auto-tune-vllm logs --study-name {config.study_name} --database-url {log_database_url}[/blue]")
+        console.print(
+            f"[blue]📋 View logs with: auto-tune-vllm logs --study-name {config.study_name} --database-url {log_database_url}[/blue]"  # noqa: E501
+        )
     else:
-        console.print("[blue]📋 Console logging only - no database or file logging configured[/blue]")
+        console.print(
+            "[blue]"
+            "📋 Console logging only - no database or file logging configured[/blue]"
+        )
 
 
 @app.command("optimize")
 def optimize_command(
     config: str = typer.Option(..., "--config", "-c", help="Study configuration file"),
-    backend: str = typer.Option("ray", "--backend", "-b", help="Execution backend: 'ray' (only supported option)"),
-    n_trials: Optional[int] = typer.Option(None, "--trials", "-n", help="Number of trials (overrides config)"),
-    max_concurrent: Optional[int] = typer.Option(None, "--max-concurrent", help="REQUIRED: Max concurrent trials to run simultaneously."),
+    backend: str = typer.Option(
+        "ray",
+        "--backend",
+        "-b",
+        help="Execution backend: 'ray' (only supported option)",
+    ),
+    n_trials: Optional[int] = typer.Option(
+        None, "--trials", "-n", help="Number of trials (overrides config)"
+    ),
+    max_concurrent: Optional[int] = typer.Option(
+        None,
+        "--max-concurrent",
+        help="REQUIRED: Max concurrent trials to run simultaneously.",
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose logging"),
-    create_db: bool = typer.Option(False, "--create-db", help="Create database if it doesn't exist"),
-    start_ray_head: bool = typer.Option(True, "--start-ray-head/--no-start-ray-head", help="Start Ray head if no cluster is found (default: True)"),
-    python_executable: Optional[str] = typer.Option(None, "--python-executable", help="Explicit Python executable path for Ray workers"),
-    venv_path: Optional[str] = typer.Option(None, "--venv-path", help="Virtual environment path for Ray workers"),
-    conda_env: Optional[str] = typer.Option(None, "--conda-env", help="Conda environment name for Ray workers"),
+    create_db: bool = typer.Option(
+        False, "--create-db", help="Create database if it doesn't exist"
+    ),
+    start_ray_head: bool = typer.Option(
+        True,
+        "--start-ray-head/--no-start-ray-head",
+        help="Start Ray head if no cluster is found (default: True)",
+    ),
+    python_executable: Optional[str] = typer.Option(
+        None,
+        "--python-executable",
+        help="Explicit Python executable path for Ray workers",
+    ),
+    venv_path: Optional[str] = typer.Option(
+        None, "--venv-path", help="Virtual environment path for Ray workers"
+    ),
+    conda_env: Optional[str] = typer.Option(
+        None, "--conda-env", help="Conda environment name for Ray workers"
+    ),
 ):
     """Run optimization study."""
     setup_logging(verbose)
-    
+
     # Validate Python environment options (exactly one should be specified)
     python_env_options = [python_executable, venv_path, conda_env]
     specified_options = [opt for opt in python_env_options if opt is not None]
-    
+
     if len(specified_options) == 0:
-        console.print("[bold red]Error: At least one Python environment option must be specified[/bold red]")
+        console.print(
+            "[bold red]"
+            "Error: At least one Python environment option must be specified"
+            "[/bold red]"
+        )
         console.print("Choose one of: --python-executable, --venv-path, or --conda-env")
         raise typer.Exit(1)
-    
+
     if len(specified_options) > 1:
-        console.print("[bold red]Error: Only one Python environment option can be specified at a time[/bold red]")
+        console.print(
+            "[bold red]"
+            "Error: Only one Python environment option can be specified at a time"
+            "[/bold red]"
+        )
         console.print("Choose one of: --python-executable, --venv-path, or --conda-env")
         raise typer.Exit(1)
-    
+
     console.print("[bold green]Starting auto-tune-vllm optimization[/bold green]")
     console.print(f"Configuration: {config}")
     console.print(f"Backend: {backend}")
-    
+
     # Display Python environment configuration
     if python_executable:
         console.print(f"Python executable: {python_executable}")
@@ -136,60 +180,85 @@ def optimize_command(
     elif conda_env:
         console.print(f"Conda environment: {conda_env}")
     elif backend.lower() == "ray":
-        console.print("[yellow]No Python environment specified, using auto-detection[/yellow]")
-    
+        console.print(
+            "[yellow]No Python environment specified, using auto-detection[/yellow]"
+        )
+
     try:
         # Load configuration
         config_path = Path(config)
         if not config_path.exists():
-            console.print(f"[bold red]Error: Configuration file not found: {config}[/bold red]")
+            console.print(
+                f"[bold red]Error: Configuration file not found: {config}[/bold red]"
+            )
             raise typer.Exit(1)
-        
+
         study_config = StudyConfig.from_file(config)
         console.print(f"Loaded study: {study_config.study_name}")
-        
+
         # Save config file to study folder
         save_config_to_study_folder(config, study_config)
-        
+
         # Create execution backend
         if backend.lower() == "ray":
             execution_backend = RayExecutionBackend(
                 start_ray_head=start_ray_head,
                 python_executable=python_executable,
                 venv_path=venv_path,
-                conda_env=conda_env
+                conda_env=conda_env,
             )
             console.print("[blue]Using Ray distributed execution[/blue]")
             if start_ray_head:
-                console.print("[blue]Will auto-start Ray head if no cluster found[/blue]")
+                console.print(
+                    "[blue]Will auto-start Ray head if no cluster found[/blue]"
+                )
             else:
-                console.print("[yellow]Ray auto-start disabled - requires existing cluster[/yellow]")
+                console.print(
+                    "[yellow]"
+                    "Ray auto-start disabled - requires existing cluster"
+                    "[/yellow]"
+                )
         else:
-            console.print("[bold red]Error: Local execution backend is not supported in this version.[/bold red]")
-            console.print("[bold red]Only Ray distributed execution is available.[/bold red]")
-            console.print("[blue]Use --backend ray (default) or set up a Ray cluster.[/blue]")
-            console.print("[blue]See docs/ray_cluster_setup.md for Ray setup instructions.[/blue]")
+            console.print(
+                "[bold red]"
+                "Error: Local execution backend is not supported in this version."
+                "[/bold red]"
+            )
+            console.print(
+                "[bold red]Only Ray distributed execution is available.[/bold red]"
+            )
+            console.print(
+                "[blue]Use --backend ray (default) or set up a Ray cluster.[/blue]"
+            )
+            console.print(
+                "[blue]See docs/ray_cluster_setup.md for Ray setup instructions.[/blue]"
+            )
             raise typer.Exit(1)
-        
+
         # Run optimization
         # Use CLI value or fall back to YAML config
-        final_max_concurrent = max_concurrent or study_config.optimization.max_concurrent
+        final_max_concurrent = (
+            max_concurrent or study_config.optimization.max_concurrent
+        )
         if final_max_concurrent is None:
-            console.print("[bold red]❌ --max-concurrent is required (or set optimization.max_concurrent in the config)[/bold red]")
-            console.print("YAML:\n  optimization:\n    max_concurrent: 2  # Match your GPU count")
+            console.print(
+                "[bold red]"
+                "❌ --max-concurrent is required "
+                "(or set optimization.max_concurrent in the config)"
+                "[/bold red]"
+            )
+            console.print(
+                "YAML:\n  optimization:\n    max_concurrent: 2  # Match your GPU count"
+            )
             raise typer.Exit(1)
         if final_max_concurrent < 1:
             console.print("[bold red]❌ --max-concurrent must be >= 1[/bold red]")
             raise typer.Exit(1)
-        
+
         run_optimization_sync(
-            execution_backend, 
-            study_config, 
-            n_trials, 
-            final_max_concurrent,
-            create_db
+            execution_backend, study_config, n_trials, final_max_concurrent, create_db
         )
-        
+
     except Exception as e:
         console.print(f"[bold red]Optimization failed: {e}[/bold red]")
         if verbose:
@@ -199,57 +268,81 @@ def optimize_command(
 
 @app.command("clear-study")
 def clear_study_command(
-    study_name: str = typer.Option(..., "--study-name", "-s", help="Name of the study to clear"),
-    database_url: str = typer.Option(..., "--database-url", "-d", help="Database URL for Optuna study data"),
-    clear_logs: bool = typer.Option(False, "--clear-logs", help="Also clear trial logs"),
-    logs_database_url: Optional[str] = typer.Option(None, "--logs-database-url", help="Logs database URL (if different from study database)"),
-    force: bool = typer.Option(False, "--force", "-f", help="Skip confirmation prompts"),
+    study_name: str = typer.Option(
+        ..., "--study-name", "-s", help="Name of the study to clear"
+    ),
+    database_url: str = typer.Option(
+        ..., "--database-url", "-d", help="Database URL for Optuna study data"
+    ),
+    clear_logs: bool = typer.Option(
+        False, "--clear-logs", help="Also clear trial logs"
+    ),
+    logs_database_url: Optional[str] = typer.Option(
+        None,
+        "--logs-database-url",
+        help="Logs database URL (if different from study database)",
+    ),
+    force: bool = typer.Option(
+        False, "--force", "-f", help="Skip confirmation prompts"
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose logging"),
 ):
     """Clear study data (trials, parameters, and optionally logs)."""
     setup_logging(verbose)
-    
+
     console.print(f"[bold yellow]Preparing to clear study: {study_name}[/bold yellow]")
-    
+
     try:
         # Verify database connections
         if not verify_database_connection(database_url):
-            console.print(f"[bold red]Error: Cannot connect to database: {database_url}[/bold red]")
+            console.print(
+                f"[bold red]"
+                f"Error: Cannot connect to database: {database_url}"
+                f"[/bold red]"
+            )
             raise typer.Exit(1)
-        
+
         logs_db_url = logs_database_url or database_url
         if clear_logs and not verify_database_connection(logs_db_url):
-            console.print(f"[bold red]Error: Cannot connect to logs database: {logs_db_url}[/bold red]")
+            console.print(
+                f"[bold red]"
+                f"Error: Cannot connect to logs database: {logs_db_url}"
+                f"[/bold red]"
+            )
             raise typer.Exit(1)
-        
+
         # Show what will be deleted
         console.print("\n[bold]The following data will be deleted:[/bold]")
         console.print(f"  • Optuna study data for '{study_name}' from {database_url}")
         if clear_logs:
             console.print(f"  • Trial logs for '{study_name}' from {logs_db_url}")
-        
+
         # Confirmation prompt
         if not force:
             confirm = typer.confirm(
                 "\nAre you sure you want to permanently delete this data?",
-                default=False
+                default=False,
             )
             if not confirm:
                 console.print("[yellow]Operation cancelled[/yellow]")
                 raise typer.Exit(0)
-        
+
         # Perform the clearing
         result = clear_study_data(study_name, database_url, clear_logs, logs_db_url)
-        
+
         if result["success"]:
-            console.print(f"[bold green]✅ Successfully cleared study '{study_name}'[/bold green]")
+            console.print(
+                f"[bold green]✅ Successfully cleared study '{study_name}'[/bold green]"
+            )
             console.print(f"  • Deleted {result['trials_deleted']} trials")
             if clear_logs:
                 console.print(f"  • Deleted {result['logs_deleted']} log entries")
         else:
-            console.print(f"[bold red]❌ Failed to clear study: {result['error']}[/bold red]")
+            console.print(
+                f"[bold red]❌ Failed to clear study: {result['error']}[/bold red]"
+            )
             raise typer.Exit(1)
-            
+
     except Exception as e:
         console.print(f"[bold red]Error clearing study: {e}[/bold red]")
         if verbose:
@@ -258,48 +351,50 @@ def clear_study_command(
 
 
 def run_optimization_sync(
-    backend, 
-    config: StudyConfig, 
-    n_trials: Optional[int], 
+    backend,
+    config: StudyConfig,
+    n_trials: Optional[int],
     max_concurrent: Optional[int],
-    create_db: bool = False
+    create_db: bool = False,
 ):
     """Synchronous optimization runner with progress display."""
     # Create study controller
-    controller = StudyController.create_from_config(backend, config, create_db=create_db)
-    
+    controller = StudyController.create_from_config(
+        backend, config, create_db=create_db
+    )
+
     # Display study name prominently in the CLI
     console.print(f"[bold cyan]🔍 Study Name: {config.study_name}[/bold cyan]")
-    
+
     # Show appropriate log viewing instructions based on logging configuration
     _display_log_viewing_instructions(config)
     console.print()  # Add blank line for better readability
-    
+
     total_trials = n_trials or config.optimization.n_trials
-    
+
     with Progress(
         SpinnerColumn(),
         TextColumn("[progress.description]{task.description}"),
-        console=console
+        console=console,
     ) as progress:
-        
         # Add progress task
         task = progress.add_task(
-            f"Running {total_trials} optimization trials...", 
-            total=total_trials
+            f"Running {total_trials} optimization trials...", total=total_trials
         )
-        
+
         try:
             # Run optimization
             controller.run_optimization(n_trials, max_concurrent)
-            
+
             # Mark task as completed
-            progress.update(task, completed=total_trials, description="✅ Optimization completed")
+            progress.update(
+                task, completed=total_trials, description="✅ Optimization completed"
+            )
         except Exception:
             # Mark task as failed and re-raise
             progress.update(task, description="❌ Optimization failed")
             raise
-    
+
     # Display results
     display_optimization_results(controller)
 
@@ -307,22 +402,22 @@ def run_optimization_sync(
 def display_optimization_results(controller: StudyController):
     """Display optimization results in a nice table."""
     results = controller.get_optimization_results()
-    
+
     console.print("\n[bold green]Optimization Results[/bold green]")
-    
+
     if results["type"] == "single_objective":
         table = Table(title="Best Trial Results")
         table.add_column("Metric", style="cyan")
         table.add_column("Value", style="green")
-        
+
         table.add_row("Total Trials", str(results["n_trials"]))
         table.add_row("Best Value", f"{results['best_value']:.4f}")
         table.add_row("Best Trial", str(results["best_trial_number"]))
-        
+
         # Add baseline comparison if available
         if results.get("baseline_value") is not None:
             table.add_row("Baseline Value", f"{results['baseline_value']:.4f}")
-            
+
             if results.get("baseline_improvement") is not None:
                 improvement = results["baseline_improvement"]
                 if improvement > 0:
@@ -331,47 +426,53 @@ def display_optimization_results(controller: StudyController):
                 else:
                     improvement_text = f"{improvement:.1f}%"
                     improvement_style = "red"
-                
-                table.add_row("Improvement", f"[{improvement_style}]{improvement_text}[/{improvement_style}]")
-        
+
+                table.add_row(
+                    "Improvement",
+                    f"[{improvement_style}]{improvement_text}[/{improvement_style}]",
+                )
+
         console.print(table)
-        
+
         # Parameters table
         params_table = Table(title="Best Parameters")
         params_table.add_column("Parameter", style="cyan")
         params_table.add_column("Value", style="yellow")
-        
+
         for param, value in results["best_params"].items():
             params_table.add_row(param, str(value))
-        
+
         console.print(params_table)
-        
+
     else:  # Multi-objective
         # Check if we have baseline comparisons
         has_baseline = results.get("baseline_values") is not None
-        
+
         if has_baseline:
             # Enhanced table with baseline comparison
             table = Table(title="Pareto-Optimal Solutions with Baseline Comparison")
             table.add_column("Trial", style="cyan")
-            
+
             # Add columns for each objective
             objectives = results["objectives"]
             for i, obj in enumerate(objectives):
                 table.add_column(f"{obj['metric']}", style="green")
                 table.add_column(f"{obj['metric']} Δ", style="yellow")
-            
+
             table.add_column("Top Parameters", style="blue")
-            
+
             for solution in results["pareto_front"][:5]:  # Show top 5
                 row_data = [str(solution["trial"])]
-                
+
                 # Add objective values and improvements
                 for i, value in enumerate(solution["values"]):
                     row_data.append(f"{value:.4f}")
-                    
+
                     # Add improvement if available
-                    if "baseline_improvements" in solution and solution["baseline_improvements"]:
+                    if (
+                        "baseline_improvements" in solution
+                        and solution["baseline_improvements"]
+                    ):
                         improvement = solution["baseline_improvements"][i]
                         if improvement is not None:
                             if improvement > 0:
@@ -382,16 +483,16 @@ def display_optimization_results(controller: StudyController):
                             improvement_text = "N/A"
                     else:
                         improvement_text = "N/A"
-                    
+
                     row_data.append(improvement_text)
-                
+
                 # Show first few parameters
                 top_params = list(solution["params"].items())[:2]
                 params_str = ", ".join(f"{k}={v}" for k, v in top_params)
                 row_data.append(params_str)
-                
+
                 table.add_row(*row_data)
-                
+
         else:
             # Original table without baseline comparison
             table = Table(title="Pareto-Optimal Solutions")
@@ -399,107 +500,158 @@ def display_optimization_results(controller: StudyController):
             table.add_column("Objective 1", style="green")
             table.add_column("Objective 2", style="green")
             table.add_column("Top Parameters", style="yellow")
-            
+
             for solution in results["pareto_front"][:5]:  # Show top 5
                 # Show first few parameters
                 top_params = list(solution["params"].items())[:3]
                 params_str = ", ".join(f"{k}={v}" for k, v in top_params)
-                
+
                 table.add_row(
                     str(solution["trial"]),
                     f"{solution['values'][0]:.4f}",
                     f"{solution['values'][1]:.4f}",
-                    params_str
+                    params_str,
                 )
-        
+
         console.print(table)
-        console.print(f"[blue]Total Pareto solutions: {results['n_pareto_solutions']}[/blue]")
-        
+        console.print(
+            f"[blue]Total Pareto solutions: {results['n_pareto_solutions']}[/blue]"
+        )
+
         # Show baseline values if available
         if has_baseline:
             baseline_table = Table(title="Baseline Values")
             baseline_table.add_column("Objective", style="cyan")
             baseline_table.add_column("Baseline Value", style="yellow")
-            
+
             for i, obj in enumerate(objectives):
                 if i < len(results["baseline_values"]):
-                    baseline_table.add_row(obj["metric"], f"{results['baseline_values'][i]:.4f}")
-            
+                    baseline_table.add_row(
+                        obj["metric"], f"{results['baseline_values'][i]:.4f}"
+                    )
+
             console.print(baseline_table)
 
 
 @app.command("logs")
 def logs_command(
     study_name: str = typer.Option(..., "--study-name", help="Study Name"),
-    database_url: Optional[str] = typer.Option(None, "--database-url", help="PostgreSQL database URL for remote logs"),
-    log_path: Optional[str] = typer.Option(None, "--log-path", help="Base log directory path for file logs"),
-    trial_number: Optional[int] = typer.Option(None, "--trial", help="Specific trial number"),
-    component: Optional[str] = typer.Option(None, "--component", help="Component (vllm, benchmark, controller)"),
-    follow: bool = typer.Option(True, "--follow/--no-follow", help="Follow logs in real-time"),
-    tail_lines: int = typer.Option(100, "--tail", "-n", help="Number of recent lines to show when starting follow mode"),
+    database_url: Optional[str] = typer.Option(
+        None, "--database-url", help="PostgreSQL database URL for remote logs"
+    ),
+    log_path: Optional[str] = typer.Option(
+        None, "--log-path", help="Base log directory path for file logs"
+    ),
+    trial_number: Optional[int] = typer.Option(
+        None, "--trial", help="Specific trial number"
+    ),
+    component: Optional[str] = typer.Option(
+        None, "--component", help="Component (vllm, benchmark, controller)"
+    ),
+    follow: bool = typer.Option(
+        True, "--follow/--no-follow", help="Follow logs in real-time"
+    ),
+    tail_lines: int = typer.Option(
+        100,
+        "--tail",
+        "-n",
+        help="Number of recent lines to show when starting follow mode",
+    ),
 ):
-    """View logs from either PostgreSQL database or local files.
-    
-    Provide either --database-url for remote database logs or --log-path for local file logs.
+    """
+    View logs from either PostgreSQL database or local files.
+
+    Provide either
+        --database-url for remote database logs or
+        --log-path for local file logs.
     """
     # Validate that exactly one logging source is provided
     if not database_url and not log_path:
-        console.print("[bold red]Error: Must specify either --database-url or --log-path[/bold red]")
+        console.print(
+            "[bold red]"
+            "Error: Must specify either --database-url or --log-path"
+            "[/bold red]"
+        )
         console.print("Examples:")
         console.print("  # View database logs:")
-        console.print("  auto-tune-vllm logs --study-name my_study --database-url postgresql://...")
+        console.print(
+            "  auto-tune-vllm logs --study-name my_study --database-url postgresql://..."
+        )
         console.print("  # View file logs:")
-        console.print("  auto-tune-vllm logs --study-name my_study --log-path /path/to/logs")
+        console.print(
+            "  auto-tune-vllm logs --study-name my_study --log-path /path/to/logs"
+        )
         raise typer.Exit(1)
-    
+
     if database_url and log_path:
-        console.print("[bold red]Error: Cannot specify both --database-url and --log-path[/bold red]")
+        console.print(
+            "[bold red]"
+            "Error: Cannot specify both --database-url and --log-path"
+            "[/bold red]"
+        )
         console.print("Choose one logging source.")
         raise typer.Exit(1)
-    
+
     if database_url:
         # Use database logging (original logs command logic)
-        console.print(f"[blue]Streaming logs for study {study_name} from database[/blue]")
+        console.print(
+            f"[blue]Streaming logs for study {study_name} from database[/blue]"
+        )
         if follow:
-            console.print(f"[dim]Showing last {tail_lines} lines, then following new logs...[/dim]")
-        
+            console.print(
+                f"[dim]"
+                f"Showing last {tail_lines} lines, then following new logs..."
+                f"[/dim]"
+            )
+
         try:
             streamer = LogStreamer(study_name, database_url)
-            
+
             # TODO: Make log streaming synchronous too
             import asyncio
+
             if trial_number is not None:
-                asyncio.run(streamer.stream_trial_logs(trial_number, component, follow, tail_lines))
+                asyncio.run(
+                    streamer.stream_trial_logs(
+                        trial_number, component, follow, tail_lines
+                    )
+                )
             else:
                 asyncio.run(streamer.stream_study_logs(follow, tail_lines))
-                
+
         except KeyboardInterrupt:
             console.print("\n[yellow]Log streaming stopped by user[/yellow]")
         except Exception as e:
             console.print(f"[bold red]Log streaming failed: {e}[/bold red]")
             raise typer.Exit(1)
-    
+
     else:
         # Use file logging (original view-file-logs command logic)
         console.print(f"[blue]Viewing file logs for study {study_name}[/blue]")
-        
+
         try:
             from pathlib import Path
-            
+
             study_dir = Path(log_path) / study_name
-            
+
             if not study_dir.exists():
-                console.print(f"[yellow]No logs found for study {study_name} in {log_path}[/yellow]")
+                console.print(
+                    f"[yellow]"
+                    f"No logs found for study {study_name} in {log_path}"
+                    "[/yellow]"
+                )
                 console.print(f"Expected directory: {study_dir}")
                 return
-            
+
             # Find log files
             if trial_number is not None:
                 trial_dir = study_dir / f"trial_{trial_number}"
                 if not trial_dir.exists():
-                    console.print(f"[yellow]No logs found for trial {trial_number}[/yellow]")
+                    console.print(
+                        f"[yellow]No logs found for trial {trial_number}[/yellow]"
+                    )
                     return
-                    
+
                 log_files = list(trial_dir.glob("*.log"))
                 if component:
                     log_files = [f for f in log_files if f.stem == component]
@@ -507,31 +659,36 @@ def logs_command(
                 log_files = list(study_dir.glob("*/*.log"))
                 if component:
                     log_files = [f for f in log_files if f.stem == component]
-            
+
             if not log_files:
                 console.print("[yellow]No log files found matching criteria[/yellow]")
                 return
-            
+
             # Sort files by modification time
             log_files.sort(key=lambda f: f.stat().st_mtime, reverse=True)
-            
+
             for log_file in log_files:
                 trial_name = log_file.parent.name
                 component_name = log_file.stem
-                
-                console.print(f"\n[bold cyan]===== {trial_name}/{component_name}.log =====[/bold cyan]")
-                
+
+                console.print(
+                    f"\n[bold cyan]"
+                    f"===== {trial_name}/{component_name}.log ====="
+                    f"[/bold cyan]"
+                )
+
                 try:
                     if follow:
                         # Simple file following
                         _follow_file(log_file)
                     else:
-                        # Show recent lines (use tail_lines parameter instead of hardcoded 'lines')
+                        # Show recent lines
+                        # (use tail_lines parameter instead of hardcoded 'lines')
                         _show_recent_lines(log_file, tail_lines)
-                        
+
                 except Exception as e:
                     console.print(f"[red]Error reading {log_file}: {e}[/red]")
-                    
+
         except KeyboardInterrupt:
             console.print("\n[yellow]Log viewing stopped by user[/yellow]")
         except Exception as e:
@@ -543,34 +700,48 @@ def logs_command(
 def view_file_logs_command(
     study_name: str = typer.Option(..., "--study-name", help="Study Name"),
     log_path: str = typer.Option(..., "--log-path", help="Base log directory path"),
-    trial_number: Optional[int] = typer.Option(None, "--trial", help="Specific trial number"),
-    component: Optional[str] = typer.Option(None, "--component", help="Component (vllm, benchmark, controller)"),
+    trial_number: Optional[int] = typer.Option(
+        None, "--trial", help="Specific trial number"
+    ),
+    component: Optional[str] = typer.Option(
+        None, "--component", help="Component (vllm, benchmark, controller)"
+    ),
     follow: bool = typer.Option(False, "--follow", help="Follow logs in real-time"),
-    lines: Optional[int] = typer.Option(50, "--lines", "-n", help="Number of recent lines to show"),
+    lines: Optional[int] = typer.Option(
+        50, "--lines", "-n", help="Number of recent lines to show"
+    ),
 ):
     """[DEPRECATED] View logs from local files. Use 'logs --log-path' instead."""
-    console.print("[yellow]⚠️  WARNING: 'view-file-logs' command is deprecated.[/yellow]")
-    console.print("[yellow]   Use 'auto-tune-vllm logs --study-name {} --log-path {}' instead.[/yellow]".format(study_name, log_path))
+    console.print(
+        "[yellow]⚠️  WARNING: 'view-file-logs' command is deprecated.[/yellow]"
+    )
+    console.print(
+        "[yellow]   Use 'auto-tune-vllm logs --study-name {study_name} --log-path {log_path}' instead.[/yellow]"  # noqa: E501
+    )
     console.print()
     console.print(f"[blue]Viewing file logs for study {study_name}[/blue]")
-    
+
     try:
         from pathlib import Path
-        
+
         study_dir = Path(log_path) / study_name
-        
+
         if not study_dir.exists():
-            console.print(f"[yellow]No logs found for study {study_name} in {log_path}[/yellow]")
+            console.print(
+                f"[yellow]No logs found for study {study_name} in {log_path}[/yellow]"
+            )
             console.print(f"Expected directory: {study_dir}")
             return
-        
+
         # Find log files
         if trial_number is not None:
             trial_dir = study_dir / f"trial_{trial_number}"
             if not trial_dir.exists():
-                console.print(f"[yellow]No logs found for trial {trial_number}[/yellow]")
+                console.print(
+                    f"[yellow]No logs found for trial {trial_number}[/yellow]"
+                )
                 return
-                
+
             log_files = list(trial_dir.glob("*.log"))
             if component:
                 log_files = [f for f in log_files if f.stem == component]
@@ -578,20 +749,24 @@ def view_file_logs_command(
             log_files = list(study_dir.glob("*/*.log"))
             if component:
                 log_files = [f for f in log_files if f.stem == component]
-        
+
         if not log_files:
             console.print("[yellow]No log files found matching criteria[/yellow]")
             return
-        
+
         # Sort files by modification time
         log_files.sort(key=lambda f: f.stat().st_mtime, reverse=True)
-        
+
         for log_file in log_files:
             trial_name = log_file.parent.name
             component_name = log_file.stem
-            
-            console.print(f"\n[bold cyan]===== {trial_name}/{component_name}.log =====[/bold cyan]")
-            
+
+            console.print(
+                f"\n[bold cyan]"
+                f"===== {trial_name}/{component_name}.log ====="
+                f"[/bold cyan]"
+            )
+
             try:
                 if follow:
                     # Simple file following
@@ -599,10 +774,10 @@ def view_file_logs_command(
                 else:
                     # Show recent lines
                     _show_recent_lines(log_file, lines)
-                    
+
             except Exception as e:
                 console.print(f"[red]Error reading {log_file}: {e}[/red]")
-                
+
     except KeyboardInterrupt:
         console.print("\n[yellow]Log viewing stopped by user[/yellow]")
     except Exception as e:
@@ -613,74 +788,140 @@ def view_file_logs_command(
 @app.command("resume")
 def resume_command(
     config: str = typer.Option(..., "--config", "-c", help="Study configuration file"),
-    backend: str = typer.Option("ray", "--backend", "-b", help="Execution backend: 'ray' (only supported option)"),
-    n_trials: Optional[int] = typer.Option(None, "--trials", "-n", help="Number of additional trials to run"),
-    n_total_trials: Optional[int] = typer.Option(None, "--total-trials", help="Total number of trials to reach (overrides config)"),
-    max_concurrent: Optional[int] = typer.Option(None, "--max-concurrent", help="REQUIRED: Max concurrent trials to run simultaneously (should match your GPU count)"),
+    backend: str = typer.Option(
+        "ray",
+        "--backend",
+        "-b",
+        help="Execution backend: 'ray' (only supported option)",
+    ),
+    n_trials: Optional[int] = typer.Option(
+        None, "--trials", "-n", help="Number of additional trials to run"
+    ),
+    n_total_trials: Optional[int] = typer.Option(
+        None,
+        "--total-trials",
+        help="Total number of trials to reach (overrides config)",
+    ),
+    max_concurrent: Optional[int] = typer.Option(
+        None,
+        "--max-concurrent",
+        help=(
+            "REQUIRED: Max concurrent trials to run simultaneously"
+            "(should match your GPU count)"
+        ),
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose logging"),
-    start_ray_head: bool = typer.Option(True, "--start-ray-head/--no-start-ray-head", help="Start Ray head if no cluster is found (default: True)"),
-    python_executable: Optional[str] = typer.Option(None, "--python-executable", help="Explicit Python executable path for Ray workers"),
-    venv_path: Optional[str] = typer.Option(None, "--venv-path", help="Virtual environment path for Ray workers"),
-    conda_env: Optional[str] = typer.Option(None, "--conda-env", help="Conda environment name for Ray workers"),
+    start_ray_head: bool = typer.Option(
+        True,
+        "--start-ray-head/--no-start-ray-head",
+        help="Start Ray head if no cluster is found (default: True)",
+    ),
+    python_executable: Optional[str] = typer.Option(
+        None,
+        "--python-executable",
+        help="Explicit Python executable path for Ray workers",
+    ),
+    venv_path: Optional[str] = typer.Option(
+        None, "--venv-path", help="Virtual environment path for Ray workers"
+    ),
+    conda_env: Optional[str] = typer.Option(
+        None, "--conda-env", help="Conda environment name for Ray workers"
+    ),
 ):
     """Resume an existing optimization study. Fails if the study doesn't exist."""
     setup_logging(verbose)
-    
+
     # Validate Python environment options (exactly one should be specified)
     python_env_options = [python_executable, venv_path, conda_env]
     specified_options = [opt for opt in python_env_options if opt is not None]
-    
+
     if len(specified_options) == 0:
-        console.print("[bold red]Error: At least one Python environment option must be specified[/bold red]")
+        console.print(
+            "[bold red]"
+            "Error: At least one Python environment option must be specified"
+            "[/bold red]"
+        )
         console.print("Choose one of: --python-executable, --venv-path, or --conda-env")
         raise typer.Exit(1)
-    
+
     if len(specified_options) > 1:
-        console.print("[bold red]Error: Only one Python environment option can be specified at a time[/bold red]")
+        console.print(
+            "[bold red]"
+            "Error: Only one Python environment option can be specified at a time"
+            "[/bold red]"
+        )
         console.print("Choose one of: --python-executable, --venv-path, or --conda-env")
         raise typer.Exit(1)
-    
+
     console.print("[bold blue]Resuming auto-tune-vllm study[/bold blue]")
-    
+
     try:
         study_config = StudyConfig.from_file(config)
-        
+
         # Save config file to study folder
         save_config_to_study_folder(config, study_config)
-        
+
         # Create backend
         if backend.lower() == "ray":
             execution_backend = RayExecutionBackend(
                 start_ray_head=start_ray_head,
                 python_executable=python_executable,
                 venv_path=venv_path,
-                conda_env=conda_env
+                conda_env=conda_env,
             )
             console.print("[blue]Using Ray distributed execution[/blue]")
             if start_ray_head:
-                console.print("[blue]Will auto-start Ray head if no cluster found[/blue]")
+                console.print(
+                    "[blue]Will auto-start Ray head if no cluster found[/blue]"
+                )
             else:
-                console.print("[yellow]Ray auto-start disabled - requires existing cluster[/yellow]")
-      
+                console.print(
+                    "[yellow]"
+                    "Ray auto-start disabled - requires existing cluster"
+                    "[/yellow]"
+                )
+
         else:
-            console.print("[bold red]Error: Local execution backend is not supported in this version.[/bold red]")
-            console.print("[bold red]Only Ray distributed execution is available.[/bold red]")
-            console.print("[blue]Use --backend ray (default) or set up a Ray cluster.[/blue]")
-            console.print("[blue]See docs/ray_cluster_setup.md for Ray setup instructions.[/blue]")
+            console.print(
+                "[bold red]"
+                "Error: Local execution backend is not supported in this version."
+                "[/bold red]"
+            )
+            console.print(
+                "[bold red]Only Ray distributed execution is available.[/bold red]"
+            )
+            console.print(
+                "[blue]Use --backend ray (default) or set up a Ray cluster.[/blue]"
+            )
+            console.print(
+                "[blue]See docs/ray_cluster_setup.md for Ray setup instructions.[/blue]"
+            )
             raise typer.Exit(1)
-        
+
         # Resume study
         # Use CLI value or fall back to YAML config
-        final_max_concurrent = max_concurrent or study_config.optimization.max_concurrent
-        if (n_trials or n_total_trials):  # Only required if we will run new trials
+        final_max_concurrent = (
+            max_concurrent or study_config.optimization.max_concurrent
+        )
+        if n_trials or n_total_trials:  # Only required if we will run new trials
             if final_max_concurrent is None:
-                console.print("[bold red]❌ --max-concurrent is required to resume with new trials[/bold red]")
+                console.print(
+                    "[bold red]"
+                    "❌ --max-concurrent is required to resume with new trials"
+                    "[/bold red]"
+                )
                 console.print("Set CLI flag or config: optimization.max_concurrent")
                 raise typer.Exit(1)
             if final_max_concurrent < 1:
                 console.print("[bold red]❌ --max-concurrent must be >= 1[/bold red]")
                 raise typer.Exit(1)
-        resume_study_sync(execution_backend, study_config, n_trials, n_total_trials, final_max_concurrent)
+        resume_study_sync(
+            execution_backend,
+            study_config,
+            n_trials,
+            n_total_trials,
+            final_max_concurrent,
+        )
 
     except Exception as e:
         console.print(f"[bold red]Resume failed: {e}[/bold red]")
@@ -690,83 +931,108 @@ def resume_command(
 
 
 def resume_study_sync(
-    backend, 
-    config: StudyConfig, 
+    backend,
+    config: StudyConfig,
     n_trials: Optional[int],
     n_total_trials: Optional[int],
-    max_concurrent: Optional[int]
+    max_concurrent: Optional[int],
 ):
     """Resume study execution."""
     controller = StudyController.resume_from_config(backend, config)
-    
+
     # Display study name prominently in the CLI
     console.print(f"[bold cyan]🔍 Study Name: {config.study_name}[/bold cyan]")
-    
+
     # Show appropriate log viewing instructions based on logging configuration
     _display_log_viewing_instructions(config)
     console.print()  # Add blank line for better readability
-    
+
     # Count existing trials to determine how many more to run
     n_existing = len(controller.study.trials)
-    
+
     # Display current results if any trials exist
     if n_existing > 0:
-        console.print(f"[bold yellow]Current Study Results ({n_existing} trials completed)[/bold yellow]")
+        console.print(
+            f"[bold yellow]Current Study Results "
+            f"({n_existing} trials completed)[/bold yellow]"
+        )
         display_optimization_results(controller)
         console.print()  # Add blank line for readability
-    
+
     if n_trials is not None:
         # --trials specifies additional trials to run
         console.print(f"Running {n_trials} additional trials...")
         controller.run_optimization(n_trials, max_concurrent)
-        
+
         # Display updated results after running additional trials
-        console.print(f"\n[bold green]Updated Study Results ({len(controller.study.trials)} total trials)[/bold green]")
+        console.print(
+            f"\n[bold green]Updated Study Results "
+            f"({len(controller.study.trials)} total trials)[/bold green]"
+        )
         display_optimization_results(controller)
-        
+
     elif n_total_trials is not None:
         # --total-trials specifies total trials to run
         if n_total_trials <= n_existing:
-            console.print(f"Study already has {n_existing} trials. Specified --total-trials={n_total_trials} would not run any new trials.")
-            console.print("Use --trials to run more trials, or increase --total-trials count.")
+            console.print(
+                f"Study already has {n_existing} trials. "
+                f"Specified --total-trials={n_total_trials} "
+                f"would not run any new trials."
+            )
+            console.print(
+                "Use --trials to run more trials, or increase --total-trials count."
+            )
         else:
             trials_to_run = n_total_trials - n_existing
-            console.print(f"Running {trials_to_run} more trials to reach total of {n_total_trials} trials...")
+            console.print(
+                f"Running {trials_to_run} more trials to reach total of "
+                f"{n_total_trials} trials..."
+            )
             controller.run_optimization(trials_to_run, max_concurrent)
-            
+
             # Display updated results after running additional trials
-            console.print(f"\n[bold green]Final Study Results ({len(controller.study.trials)} total trials)[/bold green]")
+            console.print(
+                f"\n[bold green]Final Study Results "
+                f"({len(controller.study.trials)} total trials)[/bold green]"
+            )
             display_optimization_results(controller)
-            
+
     else:
-        console.print("Study resumed. Use --trials to run additional trials or --total-trials to set total trial count.")
+        console.print(
+            "Study resumed. Use --trials to run additional trials or "
+            "--total-trials to set total trial count."
+        )
 
 
 @app.command("validate")
 def validate_command(
-    config: str = typer.Option(..., "--config", "-c", help="Configuration file to validate"),
+    config: str = typer.Option(
+        ..., "--config", "-c", help="Configuration file to validate"
+    ),
 ):
     """Validate study configuration file."""
     console.print(f"[blue]Validating configuration: {config}[/blue]")
-    
+
     try:
         config_path = Path(config)
         if not config_path.exists():
             console.print(f"[bold red]Error: File not found: {config}[/bold red]")
             raise typer.Exit(1)
-        
+
         study_config = StudyConfig.from_file(config)
-        
+
         console.print("[bold green]✓ Configuration is valid[/bold green]")
-        
+
         # Display summary
         table = Table(title="Configuration Summary")
         table.add_column("Setting", style="cyan")
         table.add_column("Value", style="green")
-        
+
         table.add_row("Study Name", study_config.study_name)
         # Safe DB/Storage display
-        storage_display = study_config.database_url or study_config.storage_file or "(none)"
+        storage_display = (
+            study_config.database_url or study_config.storage_file or "(none)"
+        )
         if isinstance(storage_display, str) and len(storage_display) > 53:
             storage_display = storage_display[:50] + "..."
         table.add_row("Database/Storage", storage_display)
@@ -775,20 +1041,31 @@ def validate_command(
             if study_config.optimization.is_multi_objective:
                 obj_summaries = []
                 for obj in study_config.optimization.objectives:
-                    obj_summaries.append(f"{obj.metric}:{obj.direction}:{obj.percentile}")
+                    obj_summaries.append(
+                        f"{obj.metric}:{obj.direction}:{obj.percentile}"
+                    )
                 opt_summary = f"multi_objective [{', '.join(obj_summaries)}]"
             else:
                 obj = study_config.optimization.objectives[0]
-                opt_summary = f"single_objective {obj.metric}:{obj.direction}:{obj.percentile}"
+                opt_summary = (
+                    f"single_objective {obj.metric}:{obj.direction}:{obj.percentile}"
+                )
         except Exception:
-            opt_summary = str(getattr(study_config.optimization, 'objective', 'unknown'))
-        table.add_row("Optimization", f"{opt_summary} ({study_config.optimization.sampler})")
+            opt_summary = str(
+                getattr(study_config.optimization, "objective", "unknown")
+            )
+        table.add_row(
+            "Optimization", f"{opt_summary} ({study_config.optimization.sampler})"
+        )
         table.add_row("Trials", str(study_config.optimization.n_trials))
         table.add_row("Model", study_config.benchmark.model)
-        table.add_row("Parameters", str(len([p for p in study_config.parameters.values() if p.enabled])))
-        
+        table.add_row(
+            "Parameters",
+            str(len([p for p in study_config.parameters.values() if p.enabled])),
+        )
+
         console.print(table)
-        
+
     except Exception as e:
         console.print(f"[bold red]Validation failed: {e}[/bold red]")
         raise typer.Exit(1)
@@ -796,75 +1073,109 @@ def validate_command(
 
 @app.command("setup-logging")
 def setup_logging_command(
-    database_url: Optional[str] = typer.Option(None, "--database-url", help="PostgreSQL database URL for logs"),
-    file_path: Optional[str] = typer.Option(None, "--file-path", help="File path for local logging"),
-    study_id: Optional[int] = typer.Option(None, "--study-id", help="Study ID (optional)"),
+    database_url: Optional[str] = typer.Option(
+        None, "--database-url", help="PostgreSQL database URL for logs"
+    ),
+    file_path: Optional[str] = typer.Option(
+        None, "--file-path", help="File path for local logging"
+    ),
+    study_id: Optional[int] = typer.Option(
+        None, "--study-id", help="Study ID (optional)"
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose logging"),
 ):
     """Setup logging infrastructure (PostgreSQL database tables or file directory).
-    
-    Note: File logging setup is optional - directories are created automatically during optimization.
-    This command is mainly useful for testing permissions and setting up PostgreSQL tables.
+
+    Note: File logging setup is optional - directories are created automatically
+    during optimization. This command is mainly useful for testing permissions
+    and setting up PostgreSQL tables.
     """
     setup_logging(verbose)
-    
+
     if not database_url and not file_path:
-        console.print("[bold red]Error: Must specify either --database-url or --file-path[/bold red]")
-        console.print("[yellow]Note: For file logging, you can just add 'file_path' to your study config - no setup required![/yellow]")
+        console.print(
+            "[bold red]Error: Must specify either "
+            "--database-url or --file-path[/bold red]"
+        )
+        console.print(
+            "[yellow]Note: For file logging, you can just add 'file_path' "
+            "to your study config - no setup required![/yellow]"
+        )
         raise typer.Exit(1)
-    
+
     console.print("[blue]Setting up logging infrastructure[/blue]")
-    
+
     try:
         if database_url:
             # Setup PostgreSQL logging
             if not verify_database_connection(database_url):
-                console.print(f"[bold red]Error: Cannot connect to database: {database_url}[/bold red]")
+                console.print(
+                    f"[bold red]Error: Cannot connect to database: "
+                    f"{database_url}[/bold red]"
+                )
                 raise typer.Exit(1)
-            
+
             # Use dummy study ID if not provided
             dummy_study_id = study_id or 0
-            
+
             # Initialize CentralizedLogger to create tables
             CentralizedLogger(
-                study_id=dummy_study_id,
-                pg_url=database_url,
-                log_level="INFO"
+                study_id=dummy_study_id, pg_url=database_url, log_level="INFO"
             )
-            
-            console.print("[bold green]✅ PostgreSQL logging tables created successfully[/bold green]")
+
+            console.print(
+                "[bold green]✅ PostgreSQL logging tables "
+                "created successfully[/bold green]"
+            )
             console.print(f"Database: {database_url}")
             console.print("Tables: trial_logs (with indexes)")
-            
+
             if study_id:
-                console.print(f"\n[blue]You can now view logs for study with ID {study_id}:[/blue]")
-                console.print(f"auto-tune-vllm logs --study-name <study_name> --database-url {database_url}")
-        
+                console.print(
+                    f"\n[blue]You can now view logs for study with "
+                    f"ID {study_id}:[/blue]"
+                )
+                console.print(
+                    "auto-tune-vllm logs --study-name <study_name> "
+                    f"--database-url {database_url}"
+                )
+
         if file_path:
             # Setup file logging
             from pathlib import Path
+
             log_dir = Path(file_path)
             log_dir.mkdir(parents=True, exist_ok=True)
-            
+
             # Test write permissions
             test_file = log_dir / "test_write.log"
             try:
-                with open(test_file, 'w') as f:
+                with open(test_file, "w") as f:
                     f.write("test\n")
                 test_file.unlink()  # Delete test file
             except Exception as e:
-                console.print(f"[bold red]Error: Cannot write to {file_path}: {e}[/bold red]")
+                console.print(
+                    f"[bold red]Error: Cannot write to {file_path}: {e}[/bold red]"
+                )
                 raise typer.Exit(1)
-            
+
             console.print("[bold green]✅ File logging directory ready[/bold green]")
             console.print(f"Log path: {file_path}")
-            console.print(f"Structure: {file_path}/<study_name>/trial_<NUM>/<component>.log")
-            console.print("[dim]Note: This setup is optional - just add 'file_path' to your study config instead![/dim]")
-            
+            console.print(
+                f"Structure: {file_path}/<study_name>/trial_<NUM>/<component>.log"
+            )
+            console.print(
+                "[dim]Note: This setup is optional - just add 'file_path' "
+                "to your study config instead![/dim]"
+            )
+
             if study_id:
                 console.print("\n[blue]You can view logs for any study with:[/blue]")
-                console.print(f"auto-tune-vllm logs --study-name <study_name> --log-path {file_path}")
-        
+                console.print(
+                    "auto-tune-vllm logs --study-name <study_name> "
+                    f"--log-path {file_path}"
+                )
+
     except Exception as e:
         console.print(f"[bold red]Failed to setup logging: {e}[/bold red]")
         if verbose:
@@ -874,26 +1185,28 @@ def setup_logging_command(
 
 @app.command("check-env")
 def check_environment_command(
-    ray_cluster: bool = typer.Option(False, "--ray-cluster", help="Check all nodes in Ray cluster"),
+    ray_cluster: bool = typer.Option(
+        False, "--ray-cluster", help="Check all nodes in Ray cluster"
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
 ):
     """Check environment and dependencies on local machine or Ray cluster."""
     setup_logging(verbose)
-    
+
     console.print("[blue]Checking environment and dependencies[/blue]")
-    
+
     try:
-        
         if ray_cluster:
             console.print("[yellow]Checking Ray cluster environment...[/yellow]")
             _check_ray_cluster_environment()
         else:
             console.print("[yellow]Checking local environment...[/yellow]")
             from ..execution.trial_controller import LocalTrialController
+
             controller = LocalTrialController()
             controller._validate_environment()
             console.print("[bold green]✓ Local environment check passed[/bold green]")
-            
+
     except Exception as e:
         console.print(f"[bold red]Environment check failed: {e}[/bold red]")
         if verbose:
@@ -905,48 +1218,58 @@ def _check_ray_cluster_environment():
     """Check environment on all Ray cluster nodes."""
     try:
         import ray
-        
+
         if not ray.is_initialized():
             console.print("[yellow]Initializing Ray connection...[/yellow]")
             ray.init(address="auto")
-        
+
         # Check head node first
         console.print("Checking head node...")
         from ..execution.trial_controller import LocalTrialController
+
         controller = LocalTrialController()
         controller._validate_environment()
         console.print("✓ Head node environment OK")
-        
+
         # Check worker nodes by running environment validation as Ray task
         @ray.remote
         def check_worker_environment():
             from auto_tune_vllm.execution.trial_controller import LocalTrialController
+
             controller = LocalTrialController()
             controller._validate_environment()
-            
+
             # Return node info
             import ray
+
             node_id = ray.get_runtime_context().get_node_id()
             return f"Worker node {node_id[:8]}"
-        
+
         # Get cluster resources to determine number of nodes
         cluster_resources = ray.cluster_resources()
-        
+
         # Run environment check on multiple workers (if available)
         console.print("Checking worker nodes...")
-        num_workers = min(4, int(cluster_resources.get("num_cpus", 1)) // 2)  # Don't overwhelm cluster
-        
+        num_workers = min(
+            4, int(cluster_resources.get("num_cpus", 1)) // 2
+        )  # Don't overwhelm cluster
+
         if num_workers > 1:
             futures = [check_worker_environment.remote() for _ in range(num_workers)]
             results = ray.get(futures)
-            
+
             for result in results:
                 console.print(f"✓ {result} environment OK")
-        
-        console.print(f"[bold green]✓ Ray cluster environment check passed ({num_workers} nodes checked)[/bold green]")
-        
+
+        console.print(
+            f"[bold green]✓ Ray cluster environment check passed "
+            f"({num_workers} nodes checked)[/bold green]"
+        )
+
     except ImportError:
-        raise RuntimeError("Ray is not installed. Cannot check Ray cluster environment.")
+        raise RuntimeError(
+            "Ray is not installed. Cannot check Ray cluster environment."
+        )
     except Exception as e:
         raise RuntimeError(f"Ray cluster environment check failed: {str(e)}")
 
@@ -955,11 +1278,12 @@ def _show_recent_lines(log_file: Path, lines: int):
     """Show recent lines from a log file."""
     try:
         import subprocess
+
         result = subprocess.run(
             ["tail", "-n", str(lines), str(log_file)],
             capture_output=True,
             text=True,
-            check=True
+            check=True,
         )
         if result.stdout:
             console.print(result.stdout)
@@ -968,9 +1292,11 @@ def _show_recent_lines(log_file: Path, lines: int):
     except subprocess.CalledProcessError:
         # Fallback to Python implementation
         try:
-            with open(log_file, 'r') as f:
+            with open(log_file, "r") as f:
                 file_lines = f.readlines()
-                recent_lines = file_lines[-lines:] if len(file_lines) > lines else file_lines
+                recent_lines = (
+                    file_lines[-lines:] if len(file_lines) > lines else file_lines
+                )
                 for line in recent_lines:
                     console.print(line.rstrip())
         except Exception as e:
@@ -980,24 +1306,25 @@ def _show_recent_lines(log_file: Path, lines: int):
 def _follow_file(log_file: Path):
     """Follow a log file in real-time."""
     console.print(f"[blue]Following {log_file} (Press Ctrl+C to stop)[/blue]")
-    
+
     try:
         import subprocess
+
         process = subprocess.Popen(
             ["tail", "-f", str(log_file)],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
             bufsize=1,
-            universal_newlines=True
+            universal_newlines=True,
         )
-        
-        for line in iter(process.stdout.readline, ''):
+
+        for line in iter(process.stdout.readline, ""):
             console.print(line.rstrip())
-            
+
     except KeyboardInterrupt:
         console.print("\n[yellow]Stopped following file[/yellow]")
-        if 'process' in locals():
+        if "process" in locals():
             process.terminate()
     except Exception as e:
         console.print(f"[red]Error following file: {e}[/red]")
@@ -1007,16 +1334,24 @@ def main():
     """Main CLI entry point."""
     # Handle no arguments case
     if len(sys.argv) == 1:
-        console.print("[bold]auto-tune-vllm[/bold] - Distributed vLLM hyperparameter optimization")
+        console.print(
+            "[bold]auto-tune-vllm[/bold] - Distributed vLLM hyperparameter optimization"
+        )
         console.print("\nUse --help for available commands")
         console.print("\nQuick start:")
         console.print("  auto-tune-vllm optimize --config study.yaml")
-        console.print("  auto-tune-vllm logs --study-name my_study --database-url postgresql://...")
-        console.print("  auto-tune-vllm logs --study-name my_study --log-path /path/to/logs")
+        console.print(
+            "  auto-tune-vllm logs --study-name my_study --database-url postgresql://..."
+        )
+        console.print(
+            "  auto-tune-vllm logs --study-name my_study --log-path /path/to/logs"
+        )
         console.print("  auto-tune-vllm setup-logging --database-url postgresql://...")
-        console.print("  auto-tune-vllm clear-study --study-name my_study --database-url postgresql://...")
+        console.print(
+            "  auto-tune-vllm clear-study --study-name my_study --database-url postgresql://..."
+        )
         sys.exit(0)
-    
+
     app()
 
 

--- a/auto_tune_vllm/core/db_utils.py
+++ b/auto_tune_vllm/core/db_utils.py
@@ -185,23 +185,23 @@ def clear_study_data(
                 # Delete in order respecting foreign key constraints
                 # Delete trial-related data first
                 cur.execute(
-                    "DELETE FROM trial_intermediate_values WHERE trial_id IN (SELECT trial_id FROM trials WHERE study_id = %s)",
+                    "DELETE FROM trial_intermediate_values WHERE trial_id IN (SELECT trial_id FROM trials WHERE study_id = %s)",  # noqa: E501
                     (optuna_study_id,),
                 )
                 cur.execute(
-                    "DELETE FROM trial_system_attributes WHERE trial_id IN (SELECT trial_id FROM trials WHERE study_id = %s)",
+                    "DELETE FROM trial_system_attributes WHERE trial_id IN (SELECT trial_id FROM trials WHERE study_id = %s)",  # noqa: E501
                     (optuna_study_id,),
                 )
                 cur.execute(
-                    "DELETE FROM trial_user_attributes WHERE trial_id IN (SELECT trial_id FROM trials WHERE study_id = %s)",
+                    "DELETE FROM trial_user_attributes WHERE trial_id IN (SELECT trial_id FROM trials WHERE study_id = %s)",  # noqa: E501
                     (optuna_study_id,),
                 )
                 cur.execute(
-                    "DELETE FROM trial_values WHERE trial_id IN (SELECT trial_id FROM trials WHERE study_id = %s)",
+                    "DELETE FROM trial_values WHERE trial_id IN (SELECT trial_id FROM trials WHERE study_id = %s)",  # noqa: E501
                     (optuna_study_id,),
                 )
                 cur.execute(
-                    "DELETE FROM trial_params WHERE trial_id IN (SELECT trial_id FROM trials WHERE study_id = %s)",
+                    "DELETE FROM trial_params WHERE trial_id IN (SELECT trial_id FROM trials WHERE study_id = %s)",  # noqa: E501
                     (optuna_study_id,),
                 )
 
@@ -218,7 +218,8 @@ def clear_study_data(
                 result["trials_deleted"] = trials_count
 
                 logger.info(
-                    f"Deleted {trials_count} trials and study '{study_name}' from Optuna database"
+                    f"Deleted {trials_count} trials "
+                    f"and study '{study_name}' from Optuna database"
                 )
 
         # Clear trial logs if requested

--- a/auto_tune_vllm/core/study_controller.py
+++ b/auto_tune_vllm/core/study_controller.py
@@ -19,8 +19,9 @@ from optuna.samplers import (
 
 from ..execution.backends import ExecutionBackend, JobHandle
 from ..logging.manager import CentralizedLogger
-from .config import EnvironmentParameter, ListParameter, RangeParameter, StudyConfig
+from .config import StudyConfig
 from .db_utils import create_database_if_not_exists, verify_database_connection
+from .parameters import EnvironmentParameter, ListParameter, RangeParameter
 from .trial import TrialConfig
 
 logger = logging.getLogger(__name__)
@@ -35,11 +36,11 @@ class StudyController:
     def __init__(
         self, backend: ExecutionBackend, study: optuna.Study, config: StudyConfig
     ):
-        self.backend = backend
-        self.study = study
-        self.config = config
+        self.backend: ExecutionBackend = backend
+        self.study: optuna.Study = study
+        self.config: StudyConfig = config
         self.active_trials: Dict[str, JobHandle] = {}
-        self.completed_trials = 0
+        self.completed_trials: int = 0
         self.baseline_results: Dict[
             int, List[float]
         ] = {}  # concurrency -> objective_values
@@ -195,8 +196,7 @@ class StudyController:
             # Provide appropriate log viewing instructions
             if log_file_path:
                 logger.info(
-                    f"📋 File logging enabled. "
-                    f"Logs will be written to: {log_file_path}"
+                    f"📋 File logging enabled. Logs will be written to: {log_file_path}"
                 )
                 logger.info(
                     f"📋 View logs with: auto-tune-vllm logs "
@@ -338,8 +338,7 @@ class StudyController:
             # Provide appropriate log viewing instructions
             if log_file_path:
                 logger.info(
-                    f"📋 File logging enabled. "
-                    f"Logs will be written to: {log_file_path}"
+                    f"📋 File logging enabled. Logs will be written to: {log_file_path}"
                 )
                 logger.info(
                     f"📋 View logs with: auto-tune-vllm logs "
@@ -375,6 +374,50 @@ class StudyController:
         return cls(backend, study, config)
 
     @staticmethod
+    def _create_search_space(config: StudyConfig) -> dict:
+        search_space = {}
+        for param_name, param_config in config.parameters.items():
+            if param_config.enabled:
+                # Convert parameter config to grid search space
+                if isinstance(param_config, ListParameter) or isinstance(
+                    param_config, EnvironmentParameter
+                ):
+                    search_space[param_name] = param_config.options
+                elif isinstance(param_config, RangeParameter):
+                    values = []
+                    min_val = param_config.min_value
+                    max_val = param_config.max_value
+                    step = param_config.step or 1
+
+                    # Use integer-based generation for floats
+                    # to avoid accumulation drift
+                    if param_config.data_type == "float":
+                        # Calculate number of steps and generate via multiplication
+                        n_steps = int((max_val - min_val) / step) + 1
+                        # Cap to reasonable grid size
+                        n_steps = min(n_steps, 10000)
+                        for i in range(n_steps):
+                            val = min_val + (i * step)
+                            if val > max_val:
+                                break
+                            # Round to avoid floating precision artifacts
+                            values.append(round(val, 3))
+                    else:
+                        # Integer range - simple iteration
+                        current = min_val
+                        while current <= max_val:
+                            values.append(current)
+                            current += step
+                            # Safety break for large ranges
+                            if len(values) > 10000:
+                                break
+                    search_space[param_name] = values
+                else:
+                    search_space[param_name] = [True, False]  # Boolean
+
+        return search_space
+
+    @staticmethod
     def _create_sampler(config: StudyConfig) -> optuna.samplers.BaseSampler:
         """Create Optuna sampler from configuration."""
         sampler_name = config.optimization.sampler.lower()
@@ -391,47 +434,7 @@ class StudyController:
             return NSGAIISampler()
         elif sampler_name == "grid":
             # Build search space for grid sampler
-            search_space = {}
-            for param_name, param_config in config.parameters.items():
-                if param_config.enabled:
-                    # Convert parameter config to grid search space
-                    if isinstance(param_config, ListParameter) or isinstance(
-                        param_config, EnvironmentParameter
-                    ):
-                        search_space[param_name] = param_config.options
-                    elif isinstance(param_config, RangeParameter):
-                        # Generate discrete values for range parameters
-                        values = []
-                        min_val = param_config.min_value
-                        max_val = param_config.max_value
-                        step = param_config.step or 1
-
-                        # Use integer-based generation for floats
-                        # to avoid accumulation drift
-                        if isinstance(min_val, float) or isinstance(step, float):
-                            # Calculate number of steps and generate via multiplication
-                            n_steps = int((max_val - min_val) / step) + 1
-                            # Cap to reasonable grid size
-                            n_steps = min(n_steps, 10000)
-                            for i in range(n_steps):
-                                val = min_val + (i * step)
-                                if val > max_val:
-                                    break
-                                # Round to avoid floating precision artifacts
-                                values.append(round(val, 3))
-                        else:
-                            # Integer range - simple iteration
-                            current = min_val
-                            while current <= max_val:
-                                values.append(current)
-                                current += step
-                                # Safety break for large ranges
-                                if len(values) > 10000:
-                                    break
-                        search_space[param_name] = values
-                    else:
-                        search_space[param_name] = [True, False]  # Boolean
-
+            search_space = StudyController._create_search_space(config)
             grid_size = StudyController._calculate_grid_size(search_space)
             logger.info(
                 f"Grid search space: {len(search_space)} parameters, "
@@ -439,8 +442,8 @@ class StudyController:
             )
             return GridSampler(search_space)
         else:
-            logger.warning(f"Unknown sampler: {sampler_name}, using TPE")
-            return TPESampler()
+            logger.warning(f"Unknown sampler: {sampler_name}")
+            raise NotImplementedError
 
     @staticmethod
     def _calculate_grid_size(search_space: Dict) -> int:
@@ -483,7 +486,7 @@ class StudyController:
             raise ValueError("--max-concurrent must be >= 1")
 
         max_concurrent_str = (
-            max_concurrent if max_concurrent != float('inf') else 'unlimited'
+            max_concurrent if max_concurrent != float("inf") else "unlimited"
         )
         logger.info(
             f"Starting optimization: {total_trials} trials, "
@@ -641,7 +644,7 @@ class StudyController:
 
                 elif result.trial_type == "baseline":
                     baseline_result = (
-                        result.objective_values if result.success else 'failed'
+                        result.objective_values if result.success else "failed"
                     )
                     logger.info(
                         f"Baseline trial {trial_id} completed: {baseline_result}"
@@ -882,13 +885,11 @@ class StudyController:
 
                 timeout_seconds = TWO_HOURS_IN_SECONDS
                 start_time = time.time()
-                poll_interval = POLL_RATE # Poll every 5 seconds
+                poll_interval = POLL_RATE  # Poll every 5 seconds
 
                 while time.time() - start_time < timeout_seconds:
                     # Poll for completion
-                    completed_results, remaining_handles = self.backend.poll_trials(
-                        [job_handle]
-                    )
+                    completed_results, _ = self.backend.poll_trials([job_handle])
 
                     if completed_results:
                         # Trial completed

--- a/auto_tune_vllm/core/study_controller.py
+++ b/auto_tune_vllm/core/study_controller.py
@@ -442,9 +442,11 @@ class StudyController:
             )
             return GridSampler(search_space)
         else:
-            logger.warning(f"Unknown sampler: {sampler_name}")
-            raise NotImplementedError
-
+        else:
+            raise NotImplementedError(
+                f"Unknown sampler '{sampler_name}'. Supported samplers: "
+                "tpe, random, gp, botorch, nsga2, grid"
+            )
     @staticmethod
     def _calculate_grid_size(search_space: Dict) -> int:
         """Calculate total grid search combinations."""

--- a/auto_tune_vllm/core/trial.py
+++ b/auto_tune_vllm/core/trial.py
@@ -99,7 +99,8 @@ class TrialConfig:
         # Add static environment variables first
         env_vars.update(self.static_environment_variables)
 
-        # Add optimizable environment variables from parameters (can override static ones)
+        # Add optimizable environment variables from parameters
+        # (can override static ones)
         for param_name, value in self.parameters.items():
             if self._is_environment_parameter(param_name):
                 env_vars[param_name] = str(value)

--- a/auto_tune_vllm/execution/backends.py
+++ b/auto_tune_vllm/execution/backends.py
@@ -132,13 +132,14 @@ class RayExecutionBackend(ExecutionBackend):
                 # We're in a virtual environment
                 runtime_env["python"] = current_python
                 logger.info(
-                    f"Auto-detected virtual environment, Ray workers will use: {current_python}"
+                    f"Auto-detected virtual environment, "
+                    f"Ray workers will use: {current_python}"
                 )
             else:
                 logger.warning(
                     "No Python environment specified and not in a virtual environment. "
-                    "Ray workers may use different Python installations. "
-                    "Consider using --python-executable, --venv-path, or --conda-env options."
+                    "Ray workers may use different Python installations. Consider using"
+                    " --python-executable, --venv-path, or --conda-env options."
                 )
 
         return runtime_env
@@ -163,12 +164,14 @@ class RayExecutionBackend(ExecutionBackend):
                     else:
                         raise RuntimeError(
                             f"Failed to connect to Ray cluster: {e}\n"
-                            f"Use --start-ray-head to automatically start a Ray head, or start one manually:\n"
+                            f"Use --start-ray-head to automatically start a Ray head, "
+                            f"or start one manually:\n"
                             f"  ray start --head --port=10001"
                         )
         except ImportError:
             raise ImportError(
-                "Ray is required for RayExecutionBackend. Install with: pip install ray[default]"
+                "Ray is required for RayExecutionBackend. "
+                "Install with: pip install ray[default]"
             )
 
     def _start_ray_head(self):
@@ -186,7 +189,8 @@ class RayExecutionBackend(ExecutionBackend):
             # Check for ray available in path
             if shutil.which("ray") is None:
                 raise RuntimeError(
-                    "Ray is not installed. Cannot start Ray head. Install or add Ray to PATH."
+                    "Ray is not installed. Cannot start Ray head. "
+                    "Install or add Ray to PATH."
                 )
 
             # Start Ray head as subprocess
@@ -278,7 +282,7 @@ class RayExecutionBackend(ExecutionBackend):
             return [], job_handles
 
         # Check which trials are ready (non-blocking)
-        ready_refs, pending_refs = ray.wait(
+        ready_refs, _ = ray.wait(
             active_refs, num_returns=len(active_refs), timeout=0
         )
 
@@ -478,4 +482,3 @@ class LocalExecutionBackend(ExecutionBackend):
         """Shutdown thread pool executor."""
         self.executor.shutdown(wait=True)
         logger.info("Shutdown local execution backend")
-

--- a/auto_tune_vllm/execution/trial_controller.py
+++ b/auto_tune_vllm/execution/trial_controller.py
@@ -76,7 +76,7 @@ class BaseTrialController(TrialController):
             missing_list = "\n  - ".join(missing_packages)
             raise RuntimeError(
                 f"Missing required packages on Ray worker node:\n  - {missing_list}\n\n"
-                f"Ray worker nodes must have the same Python environment as the head node.\n"
+                f"Ray worker nodes must have the same Python environment as the head node.\n"  # noqa: E501
                 f"Install auto-tune-vllm on all Ray cluster nodes:\n"
                 f"  pip install auto-tune-vllm"
             )
@@ -250,7 +250,10 @@ class BaseTrialController(TrialController):
         #         detailed_metrics={},
         #         execution_info=execution_info,
         #         success=False,
-        #         error_message="Parallelism is set lower than MIN_GPUS in the static_environment_variables",
+        #         error_message=(
+        #             "Parallelism is set lower than MIN_GPUS "
+        #             "in the static_environment_variables"
+        #         ),
         #     )
 
         try:

--- a/auto_tune_vllm/logging/manager.py
+++ b/auto_tune_vllm/logging/manager.py
@@ -345,7 +345,10 @@ class LogStreamer:
                     log_id, timestamp, level, trial_num, comp, message, worker = (
                         log_entry
                     )
-                    formatted_log = f"[{timestamp}] [T{trial_num}] [{worker[:8]}] {comp}.{level}: {message}"
+                    formatted_log = (
+                        f"[{timestamp}] [T{trial_num}] [{worker[:8]}] {comp}.{level}: "
+                        f"{message}"
+                    )
                     print(formatted_log)
 
                 # Set last_seen_id to the highest ID from recent logs
@@ -363,7 +366,10 @@ class LogStreamer:
                         log_entry
                     )
 
-                    formatted_log = f"[{timestamp}] [T{trial_num}] [{worker[:8]}] {comp}.{level}: {message}"
+                    formatted_log = (
+                        f"[{timestamp}] [T{trial_num}] [{worker[:8]}] {comp}.{level}: "
+                        f"{message}"
+                    )
                     print(formatted_log)
 
                     last_seen_id = max(last_seen_id, log_id)
@@ -391,7 +397,7 @@ class LogStreamer:
                         FROM trial_logs 
                         WHERE study_name = %s
                         ORDER BY id DESC LIMIT %s
-                    """,
+                    """,  # noqa: E501
                         (self.study_name, limit),
                     )
 
@@ -415,7 +421,7 @@ class LogStreamer:
                         FROM trial_logs 
                         WHERE study_name = %s AND id > %s
                         ORDER BY id ASC LIMIT 100
-                    """,
+                    """,  # noqa: E501
                         (self.study_name, last_seen_id),
                     )
 
@@ -424,4 +430,3 @@ class LogStreamer:
         except Exception as e:
             logger.error(f"Failed to fetch study logs: {e}")
             return []
-


### PR DESCRIPTION
# Summary

Additional linting fixes for the main bulk of the code in `auto_tune_vllm`. Small refactoring to break out additional functions. 

# Notable

- `_create_search_space` method that defines the full search space in a dictionary, should be passed to all samplers
- ignore SQL queries with `noqa: E501`

# Questions

Is there dead parts of the code that we can start deleting? I see that `src` is not actually touched in the CLI. Maybe in another pull request?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Benchmarks now report standard statistics (mean, median, mode, min, max, std dev, variance).
  - CLI: resume command now accepts a backend parameter.

- Refactor
  - Clearer validation and error messages in benchmarking (e.g., CLI presence, model URL) and result parsing.
  - Centralized grid search space creation; unknown samplers now raise explicit errors.
  - Minor log formatting and UI text tweaks across CLI, execution backends, and logging; no behavior changes elsewhere.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->